### PR TITLE
Propnet infrastructure

### DIFF
--- a/demo/Getting Started.ipynb
+++ b/demo/Getting Started.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/propnet/core/graph.py
+++ b/propnet/core/graph.py
@@ -300,15 +300,7 @@ class Propnet:
                     material_node.node_value.graph.add_edge(symbol_node, symbol_type_node)
 
     def shortest_path(self, property_one: str, property_two: str):
-        """
-
-        Args:
-          property_one: str: 
-          property_two: str: 
-
-        Returns:
-
-        """
+        """ """
         # very easy to do with networkx, use in-built algo
         return NotImplementedError
 

--- a/propnet/core/symbols.py
+++ b/propnet/core/symbols.py
@@ -1,4 +1,5 @@
 import numpy as np
+import sys
 
 from typing import *
 from propnet import logger, ureg
@@ -198,3 +199,20 @@ class Symbol(MSONable):
             (id): time of creation of the Symbol
         """
         return self._provenance
+
+    def __hash__(self):
+        return hash(self.type.name) + hash(self.value)
+
+    def __eq__(self, other):
+        tol = 1E-6
+        if not isinstance(other, Symbol):
+            return False
+        if self.type != other.type:
+            return False
+        if self.value == 0 or other.value == 0:
+            return self.value < tol and other.value < tol
+        elif abs(self.value) < 1.0 and abs(other.value) > abs(self.value)*sys.float_info.max:
+            return False
+        elif abs(self.value) > 1.0 and abs(other.value) < abs(self.value)*sys.float_info.min:
+            return False
+        return ((1-tol) < (self.value / other.value)) and ((self.value / other.value) < (1 + tol))

--- a/propnet/core/symbols.py
+++ b/propnet/core/symbols.py
@@ -204,15 +204,10 @@ class Symbol(MSONable):
         return hash(self.type.name) + hash(self.value)
 
     def __eq__(self, other):
-        tol = 1E-6
         if not isinstance(other, Symbol):
             return False
         if self.type != other.type:
             return False
-        if self.value == 0 or other.value == 0:
-            return self.value < tol and other.value < tol
-        elif abs(self.value) < 1.0 and abs(other.value) > abs(self.value)*sys.float_info.max:
+        if not np.isclose(self.value, other.value):
             return False
-        elif abs(self.value) > 1.0 and abs(other.value) < abs(self.value)*sys.float_info.min:
-            return False
-        return ((1-tol) < (self.value / other.value)) and ((self.value / other.value) < (1 + tol))
+        return True

--- a/propnet/core/symbols.py
+++ b/propnet/core/symbols.py
@@ -208,6 +208,6 @@ class Symbol(MSONable):
             return False
         if self.type != other.type:
             return False
-        if not np.isclose(self.value, other.value):
+        if not np.isclose(float(self.value), float(other.value)):
             return False
         return True

--- a/propnet/core/tests/test_graph.py
+++ b/propnet/core/tests/test_graph.py
@@ -24,6 +24,48 @@ class GraphTest(unittest.TestCase):
             if not isinstance(node, PropnetNode):
                 raise ValueError('Node on graph is not of valid type: {}'.format(node))
 
+    @staticmethod
+    def checkGraphSymbols(to_test, values: list, node_type: str):
+        """
+        Checks a graph instance (toTest) to see if it contains corresponding elements.
+        Cannot contain duplicates (unless they appear in values) or more than are indicated in the list.
+        Args:
+            to_test: (networkx.multiDiGraph) graph instance to check.
+            values: (list<id>) list of all node_type types that should be present in the graph.
+            node_type: (str) type of node being checked (ie. Symbol vs. SymbolType)
+        Returns: (bool) indicating whether the graph passed or not.
+        """
+        checked = list()
+        to_check = list(filter(lambda n: n.node_type == PropnetNodeType[node_type], to_test.nodes))
+        for checking in to_check:
+            v_check = checking.node_value
+            v_count = 0
+            c_count = 0
+            for value in values:
+                if value == v_check:
+                    v_count += 1
+            for value in checked:
+                if value == c_count:
+                    c_count += 1
+            if c_count >= v_count:
+                # Graph contains too many of a value.
+                return False
+            checked.append(v_check)
+        for checking in checked:
+            v_check = checking
+            v_count = 0
+            c_count = 0
+            for value in values:
+                if value == v_check:
+                    v_count += 1
+            for value in checked:
+                if value == v_check:
+                    c_count += 1
+            if v_count != c_count:
+                # Graph is missing value(s).
+                return False
+        return True
+
     def testEvaluateMethod1(self):
         """
         Graph has one material on it: mat1
@@ -35,6 +77,7 @@ class GraphTest(unittest.TestCase):
             sqrt(3), sqrt(5), sqrt(6), sqrt(10)
 
         """
+        # Setup
         propnet = Propnet()
         mat1 = Material()
         mat1.add_property(Symbol(SymbolType['relative_permeability'], 1, None))
@@ -45,26 +88,107 @@ class GraphTest(unittest.TestCase):
 
         propnet.evaluate(material=mat1)
 
-        print(propnet)
+        # Expected outputs
+        s_outputs = []
+        s_outputs.append(Symbol(SymbolType['relative_permeability'], 1, None))
+        s_outputs.append(Symbol(SymbolType['relative_permeability'], 2, None))
+        s_outputs.append(Symbol(SymbolType['relative_permittivity'], 3, None))
+        s_outputs.append(Symbol(SymbolType['relative_permittivity'], 5, None))
+        s_outputs.append(Symbol(SymbolType['refractive_index'], 3 ** 0.5, None))
+        s_outputs.append(Symbol(SymbolType['refractive_index'], 5 ** 0.5, None))
+        s_outputs.append(Symbol(SymbolType['refractive_index'], 6 ** 0.5, None))
+        s_outputs.append(Symbol(SymbolType['refractive_index'], 10 ** 0.5, None))
 
-        materialNodes = propnet.nodes_by_type('Material')
-        symbolNodes = propnet.nodes_by_type('Symbol')
+        m_outputs = [mat1]
 
-        if len(materialNodes) != 1:
-            raise ValueError('No material node appears on TestGraph1')
-        properties = [n.node_value for n in symbolNodes]
-        if len(list(filter(lambda n: n.type == SymbolType['relative_permeability'], properties))) != 2:
-            raise ValueError('Missing relative_permeability symbols')
-        for item in filter(lambda n: n.type == SymbolType['relative_permeability'], properties):
-            if item.value not in [1, 2]:
-                raise ValueError('relative_permeability improperly mutated')
-        if len(list(filter(lambda n: n.type == SymbolType['relative_permittivity'], properties))) != 2:
-            raise ValueError('Missing relative_permittivity symbols')
-        for item in filter(lambda n: n.type == SymbolType['relative_permittivity'], properties):
-            if item.value not in [3, 5]:
-                raise ValueError('relative_permeability improperly mutated')
-        if len(list(filter(lambda n: n.type == SymbolType['refractive_index'], properties))) != 4:
-            raise ValueError('Missing refractive_index nodes.')
-        for item in filter(lambda n: n.type == SymbolType['refractive_index'], properties):
-            if int(item.value ** 2 + 0.5) not in [3, 5, 6, 10]:
-                raise ValueError('refractive_index improperly calculated')
+        st_outputs = []
+        st_outputs.append(SymbolType['relative_permeability'])
+        st_outputs.append(SymbolType['relative_permittivity'])
+        st_outputs.append(SymbolType['refractive_index'])
+
+        # Test
+        if not GraphTest.checkGraphSymbols(mat1.graph, s_outputs, 'Symbol'):
+            raise ValueError('Graph symbol structure incorrect.')
+        if not GraphTest.checkGraphSymbols(mat1.graph, m_outputs, 'Material'):
+            raise ValueError('Graph material structure incorrect.')
+        if not GraphTest.checkGraphSymbols(mat1.graph, st_outputs, 'SymbolType'):
+            raise ValueError('Graph symbol type structure incorrect.')
+
+        if not GraphTest.checkGraphSymbols(propnet.graph, s_outputs, 'Symbol'):
+            raise ValueError('Graph symbol structure incorrect.')
+        if not GraphTest.checkGraphSymbols(propnet.graph, m_outputs, 'Material'):
+            raise ValueError('Graph material structure incorrect.')
+
+    def testEvaluateMethod2(self):
+        """
+        Graph has two materials on it: mat1 & mat2
+            mat1 has nondegenerate properties relative permittivity and relative permeability
+            mat2 has nondegenerate properties relative permittivity and relative permeability
+        Determines if TestGraph1 is correctly evaluated using the evaluate method.
+        We expect 4 refractive_index properties to be calculated as the following:
+            sqrt(3), sqrt(5), sqrt(6), sqrt(10)
+        We expect each material graph to have 2 include refractive_index nodes.
+        We expect each property jointly calculated to have a joint_material tag element.
+        """
+        # Setup
+        propnet = Propnet()
+        mat1 = Material()
+        mat2 = Material()
+        mat1.add_property(Symbol(SymbolType['relative_permeability'], 1, None))
+        mat2.add_property(Symbol(SymbolType['relative_permeability'], 2, None))
+        mat1.add_property(Symbol(SymbolType['relative_permittivity'], 3, None))
+        mat2.add_property(Symbol(SymbolType['relative_permittivity'], 5, None))
+        propnet.add_material(mat1)
+        propnet.add_material(mat2)
+
+        propnet.evaluate()
+
+        # Expected propnet outputs
+        s_outputs = []
+        s_outputs.append(Symbol(SymbolType['relative_permeability'], 1, None))
+        s_outputs.append(Symbol(SymbolType['relative_permeability'], 2, None))
+        s_outputs.append(Symbol(SymbolType['relative_permittivity'], 3, None))
+        s_outputs.append(Symbol(SymbolType['relative_permittivity'], 5, None))
+        s_outputs.append(Symbol(SymbolType['refractive_index'], 3 ** 0.5, None))
+        s_outputs.append(Symbol(SymbolType['refractive_index'], 5 ** 0.5, None))
+        s_outputs.append(Symbol(SymbolType['refractive_index'], 6 ** 0.5, None))
+        s_outputs.append(Symbol(SymbolType['refractive_index'], 10 ** 0.5, None))
+
+        m_outputs = [mat1, mat2]
+
+        # Expected mat_1 outputs
+        m1_s_outputs = []
+        m1_s_outputs.append(Symbol(SymbolType['relative_permeability'], 1, None))
+        m1_s_outputs.append(Symbol(SymbolType['relative_permittivity'], 3, None))
+        m1_s_outputs.append(Symbol(SymbolType['refractive_index'], 3 ** 0.5, None))
+
+        #Expected mat_2 outputs
+        m2_s_outputs = []
+        m2_s_outputs.append(Symbol(SymbolType['relative_permeability'], 2, None))
+        m2_s_outputs.append(Symbol(SymbolType['relative_permittivity'], 5, None))
+        m2_s_outputs.append(Symbol(SymbolType['refractive_index'], 10 ** 0.5, None))
+
+        st_outputs = []
+        st_outputs.append(SymbolType['relative_permeability'])
+        st_outputs.append(SymbolType['relative_permittivity'])
+        st_outputs.append(SymbolType['refractive_index'])
+
+        # Test
+        if not GraphTest.checkGraphSymbols(mat1.graph, m1_s_outputs, 'Symbol'):
+            raise ValueError('Graph symbol structure incorrect.')
+        if not GraphTest.checkGraphSymbols(mat1.graph, [mat1], 'Material'):
+            raise ValueError('Graph material structure incorrect.')
+        if not GraphTest.checkGraphSymbols(mat1.graph, st_outputs, 'SymbolType'):
+            raise ValueError('Graph symbol type structure incorrect.')
+
+        if not GraphTest.checkGraphSymbols(mat2.graph, m2_s_outputs, 'Symbol'):
+            raise ValueError('Graph symbol structure incorrect.')
+        if not GraphTest.checkGraphSymbols(mat2.graph, [mat2], 'Material'):
+            raise ValueError('Graph material structure incorrect.')
+        if not GraphTest.checkGraphSymbols(mat2.graph, st_outputs, 'SymbolType'):
+            raise ValueError('Graph symbol type structure incorrect.')
+
+        if not GraphTest.checkGraphSymbols(propnet.graph, s_outputs, 'Symbol'):
+            raise ValueError('Graph symbol structure incorrect.')
+        if not GraphTest.checkGraphSymbols(propnet.graph, m_outputs, 'Material'):
+            raise ValueError('Graph material structure incorrect.')

--- a/propnet/core/tests/test_graph.py
+++ b/propnet/core/tests/test_graph.py
@@ -21,8 +21,7 @@ class GraphTest(unittest.TestCase):
 
         # if any node on the graph is not of type Node, raise an error
         for node in self.p.graph.nodes:
-            if not isinstance(node, PropnetNode):
-                raise ValueError('Node on graph is not of valid type: {}'.format(node))
+            assert(isinstance(node, PropnetNode))
 
     @staticmethod
     def checkGraphSymbols(to_test, values: list, node_type: str):
@@ -107,17 +106,12 @@ class GraphTest(unittest.TestCase):
         st_outputs.append(SymbolType['refractive_index'])
 
         # Test
-        if not GraphTest.checkGraphSymbols(mat1.graph, s_outputs, 'Symbol'):
-            raise ValueError('Graph symbol structure incorrect.')
-        if not GraphTest.checkGraphSymbols(mat1.graph, m_outputs, 'Material'):
-            raise ValueError('Graph material structure incorrect.')
-        if not GraphTest.checkGraphSymbols(mat1.graph, st_outputs, 'SymbolType'):
-            raise ValueError('Graph symbol type structure incorrect.')
+        assert(GraphTest.checkGraphSymbols(mat1.graph, s_outputs, 'Symbol'))
+        assert(GraphTest.checkGraphSymbols(mat1.graph, m_outputs, 'Material'))
+        assert(GraphTest.checkGraphSymbols(mat1.graph, st_outputs, 'SymbolType'))
 
-        if not GraphTest.checkGraphSymbols(propnet.graph, s_outputs, 'Symbol'):
-            raise ValueError('Graph symbol structure incorrect.')
-        if not GraphTest.checkGraphSymbols(propnet.graph, m_outputs, 'Material'):
-            raise ValueError('Graph material structure incorrect.')
+        assert(GraphTest.checkGraphSymbols(propnet.graph, s_outputs, 'Symbol'))
+        assert(GraphTest.checkGraphSymbols(propnet.graph, m_outputs, 'Material'))
 
     def testEvaluateMethod2(self):
         """
@@ -174,21 +168,13 @@ class GraphTest(unittest.TestCase):
         st_outputs.append(SymbolType['refractive_index'])
 
         # Test
-        if not GraphTest.checkGraphSymbols(mat1.graph, m1_s_outputs, 'Symbol'):
-            raise ValueError('Graph symbol structure incorrect.')
-        if not GraphTest.checkGraphSymbols(mat1.graph, [mat1], 'Material'):
-            raise ValueError('Graph material structure incorrect.')
-        if not GraphTest.checkGraphSymbols(mat1.graph, st_outputs, 'SymbolType'):
-            raise ValueError('Graph symbol type structure incorrect.')
+        assert(GraphTest.checkGraphSymbols(mat1.graph, m1_s_outputs, 'Symbol'))
+        assert(GraphTest.checkGraphSymbols(mat1.graph, [mat1], 'Material'))
+        assert(GraphTest.checkGraphSymbols(mat1.graph, st_outputs, 'SymbolType'))
 
-        if not GraphTest.checkGraphSymbols(mat2.graph, m2_s_outputs, 'Symbol'):
-            raise ValueError('Graph symbol structure incorrect.')
-        if not GraphTest.checkGraphSymbols(mat2.graph, [mat2], 'Material'):
-            raise ValueError('Graph material structure incorrect.')
-        if not GraphTest.checkGraphSymbols(mat2.graph, st_outputs, 'SymbolType'):
-            raise ValueError('Graph symbol type structure incorrect.')
+        assert(GraphTest.checkGraphSymbols(mat2.graph, m2_s_outputs, 'Symbol'))
+        assert(GraphTest.checkGraphSymbols(mat2.graph, [mat2], 'Material'))
+        assert(GraphTest.checkGraphSymbols(mat2.graph, st_outputs, 'SymbolType'))
 
-        if not GraphTest.checkGraphSymbols(propnet.graph, s_outputs, 'Symbol'):
-            raise ValueError('Graph symbol structure incorrect.')
-        if not GraphTest.checkGraphSymbols(propnet.graph, m_outputs, 'Material'):
-            raise ValueError('Graph material structure incorrect.')
+        assert(GraphTest.checkGraphSymbols(propnet.graph, s_outputs, 'Symbol'))
+        assert(GraphTest.checkGraphSymbols(propnet.graph, m_outputs, 'Material'))


### PR DESCRIPTION
Changes made to the Propnet evaluate method and accompanying test methods.

A design decision was made and is as follows:

When evaluate() is called with multiple materials, all combinations of inputs are considered to form outputs from models. When multiple materials' properties are used as input, the corresponding output will have an edge from all input material nodes to the output. This change is reflected in the Propnet.graph instance variable.

Each Material has its own graph instance variable. This graph is expanded to include new outputs from models ONLY when all input properties also originate from the material. 