### PR TITLE
Adds a simple cli

### DIFF
--- a/propnet/cli.py
+++ b/propnet/cli.py
@@ -1,15 +1,26 @@
 import argparse
+import logging
+from uuid import uuid4
 from propnet.core.models import EquationModel, PyModel
 from propnet.models import DEFAULT_MODEL_DICT
 from monty.serialization import loadfn
+from propnet.web.app import app
+from os import environ
 
 __author__ = "Joseph Montoya <montoyjh@lbl.gov>"
 __version__ = 0.1
 __date__ = "Sep 4 2018"
 
 
-def run_web_app(debug=False):
-    pass
+log = logging.getLogger(__name__)
+app.server.secret_key = environ.get('FLASK_SECRET_KEY', str(uuid4()))
+server = app.server
+
+def run_web_app(args):
+    if args.debug:
+        log.setLevel('DEBUG')
+    app.run_server(debug=args.debug)
+
 
 def validate(args):
     if args.name is not None:

--- a/propnet/cli.py
+++ b/propnet/cli.py
@@ -1,0 +1,70 @@
+import argparse
+from propnet.core.models import EquationModel, PyModel
+from propnet.models import DEFAULT_MODEL_DICT
+from monty.serialization import loadfn
+
+__author__ = "Joseph Montoya <montoyjh@lbl.gov>"
+__version__ = 0.1
+__date__ = "Sep 4 2018"
+
+
+def run_web_app(debug=False):
+    pass
+
+def validate(args):
+    if args.name is not None:
+        import nose; nose.tools.set_trace()
+        model = DEFAULT_MODEL_DICT[args.name]
+        if not args.test_data:
+            model.validate_from_preset_test()
+            print("Model validated with test data")
+            return True
+    elif args.file is not None:
+        if args.file.endswith(".yaml"):
+            EquationModel.from_file(args.file)
+        elif args.file.endswith(".py"):
+            # This should define config
+            l, g = locals().copy(), globals().copy()
+            with open(args.file) as f:
+                code = compile(f.read(), args.file, 'exec')
+                exec(code, globals())
+            config = globals().get('config')
+            model = PyModel(**config)
+
+    if args.test_data is not None:
+        td_data = loadfn(args.test_data)
+        for td_datum in td_data:
+            model.test(**td_datum)
+        print("{} validated with test data".format(model.name))
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="""
+    propnet is a command-line interface to the propnet python package""",
+                                     epilog="""
+    Author: Joseph Montoya
+    Version: {}
+    Last updated: {}""".format(__version__, __date__))
+    subparsers = parser.add_subparsers()
+
+    # Web runner
+    parser_web = subparsers.add_parser("run_web", help="Run web server")
+    parser_web.add_argument("-d", "--debug", help="Run in debug mode",
+                            action="store_true")
+    parser_web.set_defaults(func=run_web_app)
+
+    # Validate models
+    parser_validate = subparsers.add_parser(
+        "validate", help="validate models")
+    parser_validate.add_argument("-n", "--name", help="Default model name")
+    parser_validate.add_argument("-f", "--file", help="Non-default model filename")
+    parser_validate.add_argument("-t", "--test_data", help="Test data file")
+    parser_validate.set_defaults(func=validate)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/propnet/cli.py
+++ b/propnet/cli.py
@@ -1,30 +1,35 @@
+"""
+A simple command-line interface to propnet
+"""
+
 import argparse
 import logging
 from uuid import uuid4
+from os import environ
 from propnet.core.models import EquationModel, PyModel
 from propnet.models import DEFAULT_MODEL_DICT
-from monty.serialization import loadfn
 from propnet.web.app import app
-from os import environ
+from monty.serialization import loadfn
 
 __author__ = "Joseph Montoya <montoyjh@lbl.gov>"
 __version__ = 0.1
 __date__ = "Sep 4 2018"
 
 
-log = logging.getLogger(__name__)
+LOG = logging.getLogger(__name__)
 app.server.secret_key = environ.get('FLASK_SECRET_KEY', str(uuid4()))
-server = app.server
+SERVER = app.server
 
 def run_web_app(args):
+    """Runs web app"""
     if args.debug:
         log.setLevel('DEBUG')
     app.run_server(debug=args.debug)
 
 
 def validate(args):
+    """Validates test data"""
     if args.name is not None:
-        import nose; nose.tools.set_trace()
         model = DEFAULT_MODEL_DICT[args.name]
         if not args.test_data:
             model.validate_from_preset_test()
@@ -35,9 +40,8 @@ def validate(args):
             EquationModel.from_file(args.file)
         elif args.file.endswith(".py"):
             # This should define config
-            l, g = locals().copy(), globals().copy()
-            with open(args.file) as f:
-                code = compile(f.read(), args.file, 'exec')
+            with open(args.file) as this_file:
+                code = compile(this_file.read(), args.file, 'exec')
                 exec(code, globals())
             config = globals().get('config')
             model = PyModel(**config)
@@ -51,6 +55,7 @@ def validate(args):
 
 
 def main():
+    """Main body for CLI"""
     parser = argparse.ArgumentParser(description="""
     propnet is a command-line interface to the propnet python package""",
                                      epilog="""

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ setup(
     author_email='matt@mkhorton.net',
     description='Materials Science models, pre-alpha.',
     url='https://github.com/materialsintelligence/propnet',
-    download_url='https://github.com/materialsintelligence/propnet/archive/0.0.tar.gz'
+    download_url='https://github.com/materialsintelligence/propnet/archive/0.0.tar.gz',
+    entry_points={"console_scripts": ["propnet = propnet.cli:main"]}
 )


### PR DESCRIPTION
Simple cli and validation framework, enables command line validation of models, e. g.

`>>>propnet validate -n cost`

or

`>>>propnet validate -f my_model.py -t my_test_data.json`