### PR TITLE
Builder

### DIFF
--- a/propnet/core/builder.py
+++ b/propnet/core/builder.py
@@ -6,6 +6,7 @@ from propnet import logger
 from propnet.core.quantity import Quantity
 from propnet.core.materials import Material
 from propnet.core.graph import Graph
+from propnet.models import DEFAULT_MODEL_DICT
 from propnet.ext.matproj import MPRester
 from pydash import get
 
@@ -58,6 +59,7 @@ class PropnetBuilder(Builder):
         # Use graph to generate expanded quantity pool
         logger.info("Evaluating graph for %s", item['task_id'])
         graph = Graph()
+        graph.remove_models({"dimensionality": DEFAULT_MODEL_DICT['dimensionality']})
         new_material = graph.evaluate(material)
 
         # Format document and return
@@ -80,6 +82,5 @@ class PropnetBuilder(Builder):
         return jsanitize(doc, strict=True)
 
     def update_targets(self, items):
-        items = [jsanitize(item, strict=True) for item in items]
         self.propstore.update(items)
 

--- a/propnet/web/app.py
+++ b/propnet/web/app.py
@@ -253,7 +253,7 @@ material_layout = html.Div([
             {'label': 'Derive properties', 'value': 'derive'},
             {'label': 'Aggregate', 'value': 'aggregate'}
         ],
-        values=['aggregate'],
+        values=['derive', 'aggregate'],
         labelStyle={'display': 'inline-block'}
     ),
     html.Br(),


### PR DESCRIPTION
Minor quasi-bug fixes:

* Changes default evaluate load material condition to derive properties
* Temporary fix for builder to prevent dimensionality.  These models are very slow for certain materials.  In the long term, it might be better to place a timeout on model evaluation.