### PR TITLE
Vis provenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
 install:
   - pip install -r requirements.txt
+  - conda install pygraphviz
   - pip install nose
   - pip install coverage
   - pip install python-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,20 @@ services: mongodb
 python:
   - "3.6"
 install:
+  - sudo apt-get update
+  # We do this conditionally because it saves us some downloading if the
+  # version is the same.
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+  - source activate test-environment
   - pip install -r requirements.txt
   - conda install pygraphviz
   - pip install nose

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy
   - source activate test-environment
   - pip install -r requirements.txt
   - conda install pygraphviz

--- a/propnet/core/graph.py
+++ b/propnet/core/graph.py
@@ -332,7 +332,7 @@ class Graph(object):
                 nx.set_node_attributes(graph, {node: node.name}, "label")
         return graph
 
-    def create_file(self, filename='out.dot', draw=False,
+    def create_file(self, filename='out.dot', draw=False, prog='dot',
                     include_orphans=False, **kwargs):
         """
         Output the graph to a file
@@ -351,7 +351,7 @@ class Graph(object):
         agraph = nx.nx_agraph.to_agraph(nxgraph)
         agraph.node_attr['style'] = 'filled'
         if draw:
-            agraph.draw(filename, **kwargs)
+            agraph.draw(filename, prog=prog, **kwargs)
         else:
             agraph.write(filename, **kwargs)
 

--- a/propnet/core/provenance.py
+++ b/propnet/core/provenance.py
@@ -12,7 +12,7 @@ class ProvenanceElement(MSONable):
 
     __slots__ = ['m', 'inputs']
 
-    def __init__(self, model=None, inputs=None):
+    def __init__(self, model=None, inputs=None, source=None):
         """
         Args:
             model: (Model) model that outputs the quantity object this
@@ -20,6 +20,7 @@ class ProvenanceElement(MSONable):
             inputs: (list<Quantity>) quantities fed in to the model
                 to generate the quantity object this ProvenanceElement
                 is attached to.
+            source: static source, e. g. Materials Project
         """
         self.model = getattr(model, 'name', model)
         self.inputs = inputs

--- a/propnet/core/provenance.py
+++ b/propnet/core/provenance.py
@@ -24,6 +24,7 @@ class ProvenanceElement(MSONable):
         """
         self.model = getattr(model, 'name', model)
         self.inputs = inputs
+        self.source = source
 
     def __str__(self):
         pre = ",".join([

--- a/propnet/core/quantity.py
+++ b/propnet/core/quantity.py
@@ -203,9 +203,9 @@ class Quantity(MSONable):
         if model_hash in visited:
             return True
         visited.add(model_hash)
-        for input in self.provenance.inputs or []:
+        for p_input in self.provenance.inputs or []:
             this_visited = visited.copy()
-            if input.is_cyclic(this_visited):
+            if p_input.is_cyclic(this_visited):
                 return True
         return False
 

--- a/propnet/core/quantity.py
+++ b/propnet/core/quantity.py
@@ -339,14 +339,12 @@ class Quantity(MSONable):
                 graph = model_input.get_provenance_graph(start=graph)
                 graph.add_edge(model_input, model)
         elif source is not None:
-            graph.add_node(source, label=source, fillcolor='green',
-                           fontcolor='white')
-            self.add_edge(source, self)
+            graph.add_edge(source, self)
 
         return graph
 
-    def draw_provenance_graph(self, filename, **kwargs):
+    def draw_provenance_graph(self, filename, prog='dot',**kwargs):
         nx_graph = self.get_provenance_graph()
         a_graph = nx.nx_agraph.to_agraph(nx_graph)
         a_graph.node_attr['style'] = 'filled'
-        a_graph.draw(filename, **kwargs)
+        a_graph.draw(filename, prog=prog, **kwargs)

--- a/propnet/core/quantity.py
+++ b/propnet/core/quantity.py
@@ -203,7 +203,7 @@ class Quantity(MSONable):
         if model_hash in visited:
             return True
         visited.add(model_hash)
-        for input in self.provenance.inputs:
+        for input in self.provenance.inputs or []:
             this_visited = visited.copy()
             if input.is_cyclic(this_visited):
                 return True
@@ -313,7 +313,7 @@ class Quantity(MSONable):
                    tags=list(new_tags), provenance=new_provenance,
                    uncertainty=std_dev)
 
-    def get_provenance_graph(self, start=None):
+    def get_provenance_graph(self, start=None, filter_long_labels=True):
         """
         Gets an nxgraph object corresponding to the provenance graph
 
@@ -325,9 +325,12 @@ class Quantity(MSONable):
         """
         graph = start or nx.MultiDiGraph()
         # import nose; nose.tools.set_trace()
+        label = self.pretty_string()
+        label = "{}: {}".format(self.symbol.name, self.pretty_string())
+        if filter_long_labels and len(label) > 30:
+            label = "{}".format(self.symbol.name)
         graph.add_node(
-            self, fillcolor="#43A1F8", fontcolor='white',
-            label="{}: {}".format(self.symbol.name, self.pretty_string(4)))
+            self, fillcolor="#43A1F8", fontcolor='white', label=label)
         model = getattr(self.provenance, 'model', None)
         source = getattr(self.provenance, 'source', None)
         if model is not None:

--- a/propnet/core/tests/test_quantity.py
+++ b/propnet/core/tests/test_quantity.py
@@ -87,4 +87,11 @@ class QuantityTest(unittest.TestCase):
         # TODO: this should be tested more thoroughly
         out = list(evaluated['vickers_hardness'])[0]
         with tempfile.ScratchDir('.'):
-            out.draw_provenance_graph("out.png", prog='dot')
+            out.draw_provenance_graph("out.png")
+
+        from propnet.ext.matproj import MPRester
+        mpr = MPRester()
+        mat = mpr.get_material_for_mpid("mp-66")
+        evaluated = g.evaluate(mat)
+        out = list(evaluated['vickers_hardness'])[-1]
+        out.draw_provenance_graph("out.png", prog='dot')

--- a/propnet/core/tests/test_quantity.py
+++ b/propnet/core/tests/test_quantity.py
@@ -2,11 +2,14 @@ import unittest
 import os
 
 import numpy as np
+from monty import tempfile
 
 from pymatgen.util.testing import PymatgenTest
 from propnet.core.symbols import Symbol
 from propnet.core.exceptions import SymbolConstraintError
 from propnet.core.quantity import Quantity
+from propnet.core.materials import Material
+from propnet.core.graph import Graph
 from propnet import ureg
 
 
@@ -74,3 +77,14 @@ class QuantityTest(unittest.TestCase):
             print(q.units)
         with self.assertRaises(ValueError):
             print(q.magnitude)
+
+    def test_get_provenance_graph(self):
+        g = Graph()
+        mat = Material([Quantity("bulk_modulus", 100),
+                        Quantity("shear_modulus", 50),
+                        Quantity("density", 8.96)])
+        evaluated = g.evaluate(mat)
+        # TODO: this should be tested more thoroughly
+        out = list(evaluated['vickers_hardness'])[0]
+        with tempfile.ScratchDir('.'):
+            out.draw_provenance_graph("out.png", prog='dot')

--- a/propnet/core/tests/test_quantity.py
+++ b/propnet/core/tests/test_quantity.py
@@ -3,6 +3,7 @@ import os
 
 import numpy as np
 from monty import tempfile
+import networkx as nx
 
 from pymatgen.util.testing import PymatgenTest
 from propnet.core.symbols import Symbol
@@ -80,14 +81,19 @@ class QuantityTest(unittest.TestCase):
 
     def test_get_provenance_graph(self):
         g = Graph()
-        mat = Material([Quantity("bulk_modulus", 100),
-                        Quantity("shear_modulus", 50),
-                        Quantity("density", 8.96)])
+        qs = [Quantity("bulk_modulus", 100),
+              Quantity("shear_modulus", 50),
+              Quantity("density", 8.96)]
+        mat = Material(qs)
         evaluated = g.evaluate(mat)
         # TODO: this should be tested more thoroughly
         out = list(evaluated['vickers_hardness'])[0]
         with tempfile.ScratchDir('.'):
             out.draw_provenance_graph("out.png")
+        pgraph = out.get_provenance_graph()
+        end = list(evaluated['vickers_hardness'])[0]
+        shortest_lengths = nx.shortest_path_length(pgraph, qs[0])
+        self.assertEqual(shortest_lengths[end], 4)
 
         # This test is useful if one wants to actually make a plot, leaving
         # it in for now

--- a/propnet/core/tests/test_quantity.py
+++ b/propnet/core/tests/test_quantity.py
@@ -89,9 +89,11 @@ class QuantityTest(unittest.TestCase):
         with tempfile.ScratchDir('.'):
             out.draw_provenance_graph("out.png")
 
-        from propnet.ext.matproj import MPRester
-        mpr = MPRester()
-        mat = mpr.get_material_for_mpid("mp-66")
-        evaluated = g.evaluate(mat)
-        out = list(evaluated['vickers_hardness'])[-1]
-        out.draw_provenance_graph("out.png", prog='dot')
+        # This test is useful if one wants to actually make a plot, leaving
+        # it in for now
+        # from propnet.ext.matproj import MPRester
+        # mpr = MPRester()
+        # mat = mpr.get_material_for_mpid("mp-66")
+        # evaluated = g.evaluate(mat)
+        # out = list(evaluated['vickers_hardness'])[-1]
+        # out.draw_provenance_graph("out.png", prog='dot')

--- a/propnet/ext/matproj.py
+++ b/propnet/ext/matproj.py
@@ -1,5 +1,6 @@
 from propnet.core.materials import Material
 from propnet.core.quantity import Quantity
+from propnet.core.provenance import ProvenanceElement
 
 from pymatgen import MPRester as _MPRester
 
@@ -133,7 +134,9 @@ class MPRester(_MPRester):
         for material_properties in materials_properties:
             material = Material()
             for property_name, property_value in material_properties.items():
-                quantity = Quantity(self.mapping[property_name], property_value)
+                provenance = ProvenanceElement(source='Materials Project')
+                quantity = Quantity(self.mapping[property_name], property_value,
+                                    provenance=provenance)
                 material.add_quantity(quantity)
             materials.append(material)
 

--- a/propnet/ext/tests/test_matproj.py
+++ b/propnet/ext/tests/test_matproj.py
@@ -13,6 +13,8 @@ class MPResterTest(unittest.TestCase):
         mpid = 'mp-1153'
         mpr = MPRester()
         mat = mpr.get_material_for_mpid(mpid)
+        quantity = next(iter(mat['structure']))
+        self.assertEqual(quantity.provenance.source, "Materials Project")
         self.assertIn('structure', mat.get_symbols())
 
     def test_get_mpid_from_formula(self):


### PR DESCRIPTION
Quick visualizer for the provenance tree of a given quantity, example usage:

```
from propnet.ext.matproj import MPRester
from propnet.core.graph import Graph
g = Graph()
mpr = MPRester()
mat = mpr.get_material_for_mpid("mp-66")
evaluated = g.evaluate(mat)
out = list(evaluated['vickers_hardness'])[-1]
out.draw_provenance_graph("out.png")
```

![image](https://user-images.githubusercontent.com/6494516/48166236-cc96a380-e29c-11e8-90cd-9c1475e41942.png)
