### PR TITLE
Added implemented_by field to denote model authorship

### DIFF
--- a/propnet/core/models.py
+++ b/propnet/core/models.py
@@ -62,12 +62,13 @@ class Model(ABC):
             which to evaluate the model
     """
     def __init__(self, name, connections, constraints=None,
-                 description=None, categories=None, references=None,
+                 description=None, categories=None, references=None, implemented_by=None,
                  symbol_property_map=None, scrub_units=None, test_data=None):
         self.name = name
         self.connections = connections
         self.description = description
         self.categories = categories or []
+        self.implemented_by = implemented_by or []
         self.references = references_to_bib(references or [])
         # symbol property map initialized as symbol->symbol, then updated
         # with any customization of symbol to properties mapping
@@ -482,8 +483,8 @@ class EquationModel(Model, MSONable):
     """
     def __init__(self, name, equations, connections=None, constraints=None,
                  symbol_property_map=None, description=None,
-                 categories=None, references=None, scrub_units=None,
-                 solve_for_all_symbols=False, test_data=None):
+                 categories=None, references=None, implemented_by=None,
+                 scrub_units=None, solve_for_all_symbols=False, test_data=None):
 
         self.equations = equations
         sympy_expressions = [parse_expr(eq.replace('=', '-(')+')')
@@ -525,7 +526,8 @@ class EquationModel(Model, MSONable):
         self.equations = equations
         super(EquationModel, self).__init__(
             name, connections, constraints, description,
-            categories, references, symbol_property_map, scrub_units,
+            categories, references, implemented_by,
+            symbol_property_map, scrub_units,
             test_data=test_data)
 
     def plug_in(self, symbol_value_dict):
@@ -586,11 +588,13 @@ class PyModel(Model):
     """
     def __init__(self, name, connections, plug_in, constraints=None,
                  description=None, categories=None, references=None,
-                 symbol_property_map=None, scrub_units=True, test_data=None):
+                 implemented_by=None, symbol_property_map=None,
+                 scrub_units=True, test_data=None):
         self._plug_in = plug_in
         super(PyModel, self).__init__(
             name, connections, constraints, description,
-            categories, references, symbol_property_map, scrub_units,
+            categories, references, implemented_by,
+            symbol_property_map, scrub_units,
             test_data=test_data)
 
     def plug_in(self, symbol_value_dict):

--- a/propnet/core/tests/test_models.py
+++ b/propnet/core/tests/test_models.py
@@ -30,6 +30,7 @@ class ModelTest(unittest.TestCase):
             self.assertIsNotNone(model.categories)
             self.assertIsNotNone(model.description)
             self.assertIsNotNone(model.symbol_property_map)
+            self.assertIsNotNone(model.implemented_by)
             self.assertTrue(isinstance(model.symbol_property_map, dict))
             self.assertTrue(len(model.symbol_property_map.keys()) > 0)
             for key in model.symbol_property_map.keys():

--- a/propnet/models/composite/pilling_bedworth.py
+++ b/propnet/models/composite/pilling_bedworth.py
@@ -52,6 +52,9 @@ config = {
     ],
     "description": DESCRIPTION,
     "references": ["doi:10.1016/S0257-8972(02)00593-5"],
+    "implemented_by": [
+        "dmrdjenovich"
+    ],
     "plug_in": plug_in,
     "filter": filter,
     "pre_filter": pre_filter

--- a/propnet/models/python/clarke_thermal_conductivity.py
+++ b/propnet/models/python/clarke_thermal_conductivity.py
@@ -50,5 +50,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": ["doi:10.1016/S0257-8972(02)00593-5"],
+    "implemented_by": [
+        "mkhorton"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/compliance_from_elasticity.py
+++ b/propnet/models/python/compliance_from_elasticity.py
@@ -44,5 +44,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": [],
+    "implemented_by": [
+        "dmrdjenovich"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/cost.py
+++ b/propnet/models/python/cost.py
@@ -37,5 +37,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": [],
+    "implemented_by": [
+        "mkhorton"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/density.py
+++ b/propnet/models/python/density.py
@@ -42,5 +42,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": [],
+    "implemented_by": [
+        "dmrdjenovich"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/dimensionality_cheon.py
+++ b/propnet/models/python/dimensionality_cheon.py
@@ -29,5 +29,8 @@ config = {
     ],
     "description": DESCRIPTION,
     "references": ["doi:10.1039/C6TA04121C"],
+    "implemented_by": [
+        "mkhorton"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/dimensionality_gorai.py
+++ b/propnet/models/python/dimensionality_gorai.py
@@ -29,5 +29,8 @@ config = {
     ],
     "description": DESCRIPTION,
     "references": ["doi:10.1021/acs.nanolett.6b05229"],
+    "implemented_by": [
+        "mkhorton"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/gbml.py
+++ b/propnet/models/python/gbml.py
@@ -54,5 +54,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": [],
+    "implemented_by": [
+        "mkhorton"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/heat_capacity_debye.py
+++ b/propnet/models/python/heat_capacity_debye.py
@@ -33,5 +33,8 @@ config = {
     ],
     "description": DESCRIPTION,
     "references": ["doi:10.1016/j.commatsci.2012.10.028"],
+    "implemented_by": [
+        "montoyjh"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/hhi.py
+++ b/propnet/models/python/hhi.py
@@ -41,5 +41,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": ["doi:10.1021/cm400893e"],
+    "implemented_by": [
+        "mkhorton"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/hill_bulk_modulus.py
+++ b/propnet/models/python/hill_bulk_modulus.py
@@ -34,5 +34,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": [],
+    "implemented_by": [
+        "dmrdjenovich"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/hill_shear_modulus.py
+++ b/propnet/models/python/hill_shear_modulus.py
@@ -40,5 +40,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": [],
+    "implemented_by": [
+        "dmrdjenovich"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/homogeneous_elasticity_relations.py
+++ b/propnet/models/python/homogeneous_elasticity_relations.py
@@ -331,5 +331,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": ["url:https://en.wikipedia.org/wiki/Elastic_modulus"],
+    "implemented_by": [
+        "dmrdjenovich"
+    ],
     "plug_in": plug_in,
 }

--- a/propnet/models/python/is_metallic.py
+++ b/propnet/models/python/is_metallic.py
@@ -27,5 +27,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": [],
+    "implemented_by": [
+        "mkhorton"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/molar_mass_from_formula.py
+++ b/propnet/models/python/molar_mass_from_formula.py
@@ -25,5 +25,8 @@ config = {
     ],
     "description": DESCRIPTION,
     "references": [],
+    "implemented_by": [
+        "montoyjh"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/perovskite_classifier.py
+++ b/propnet/models/python/perovskite_classifier.py
@@ -45,5 +45,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": [],
+    "implemented_by": [
+        "mkhorton"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/pymatgen_structure_properties.py
+++ b/propnet/models/python/pymatgen_structure_properties.py
@@ -34,5 +34,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": ["doi:10.1016/j.commatsci.2012.10.028"],
+    "implemented_by": [
+        "mkhorton"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/pymatgen_structure_transformations.py
+++ b/propnet/models/python/pymatgen_structure_transformations.py
@@ -37,5 +37,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": ["doi:10.1016/j.commatsci.2012.10.028"],
+    "implemented_by": [
+        "mkhorton"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/reuss_bulk_modulus.py
+++ b/propnet/models/python/reuss_bulk_modulus.py
@@ -29,5 +29,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": [],
+    "implemented_by": [
+        "dmrdjenovich"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/reuss_shear_modulus.py
+++ b/propnet/models/python/reuss_shear_modulus.py
@@ -34,5 +34,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": [],
+    "implemented_by": [
+        "dmrdjenovich"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/voigt_bulk_modulus.py
+++ b/propnet/models/python/voigt_bulk_modulus.py
@@ -30,5 +30,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": [],
+    "implemented_by": [
+        "dmrdjenovich"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/python/voigt_shear_modulus.py
+++ b/propnet/models/python/voigt_shear_modulus.py
@@ -30,5 +30,8 @@ config = {
     },
     "description": DESCRIPTION,
     "references": [],
+    "implemented_by": [
+        "dmrdjenovich"
+    ],
     "plug_in": plug_in
 }

--- a/propnet/models/serialized/band_gap_refractive_index_herve_vandamme.yaml
+++ b/propnet/models/serialized/band_gap_refractive_index_herve_vandamme.yaml
@@ -14,6 +14,8 @@ description: 'Proposed as an empirical model relating a material''''s band gap t
 equations:
 - n = (1 + (13.6 / (Eg + 3.47))**2)**0.5
 name: band_gap_refractive_index_herve_vandamme
+implemented_by:
+- montoyjh
 references:
 - doi:10.1016/j.infrared.2006.04.001
 - doi:10.1002/pssb.2221310202

--- a/propnet/models/serialized/band_gap_refractive_index_moss.yaml
+++ b/propnet/models/serialized/band_gap_refractive_index_moss.yaml
@@ -9,6 +9,8 @@ description: 'An empirical model relating a material''''s band gap to its
 equations:
 - n = (95/Eg)**(1/4)
 name: band_gap_refractive_index_moss
+implemented_by:
+- mkhorton
 references:
 - doi:10.1016/j.infrared.2006.04.001
 - doi:10.1002/pssb.2221310202

--- a/propnet/models/serialized/band_gap_refractive_index_ravindra.yaml
+++ b/propnet/models/serialized/band_gap_refractive_index_ravindra.yaml
@@ -14,6 +14,8 @@ description: 'Proposed as an empirical model relating a material''''s band gap t
 equations:
 - n = 4.16 - 1.12*Eg + 0.31*Eg**2 - 0.08*Eg**2
 name: band_gap_refractive_index_ravindra
+implemented_by:
+- mkhorton
 references:
 - doi:10.1016/j.infrared.2006.04.001
 - doi:10.1002/pssb.2221310202

--- a/propnet/models/serialized/band_gap_refractive_index_reddy_ahammed.yaml
+++ b/propnet/models/serialized/band_gap_refractive_index_reddy_ahammed.yaml
@@ -9,6 +9,8 @@ description: 'An empirical model relating index of refraction to band gap
 equations:
 - Eg = 154 / n**4 + 0.365
 name: band_gap_refractive_index_reddy_ahammed
+implemented_by:
+- montoyjh
 references:
 - doi:10.1016/j.infrared.2006.04.001
 - doi:10.1002/pssb.2221310202

--- a/propnet/models/serialized/band_gap_refractive_index_reddy_anjaneyulu.yaml
+++ b/propnet/models/serialized/band_gap_refractive_index_reddy_anjaneyulu.yaml
@@ -9,6 +9,8 @@ description: 'An empirical model relating index of refraction to band gap
 equations:
 - Eg = 36.3 / exp(n)
 name: band_gap_refractive_index_reddy_anjaneyulu
+implemented_by:
+- montoyjh
 references:
 - doi:10.1016/j.infrared.2006.04.001
 - doi:10.1002/pssb.2221310202

--- a/propnet/models/serialized/belomestnikh_gruneisen.yaml
+++ b/propnet/models/serialized/belomestnikh_gruneisen.yaml
@@ -9,6 +9,8 @@ description: "An expression for the Gruneisen constants of solids is obtained\ni
 equations:
 - gamma_d = 1.5 * ((3*(v_l / v_t)**2 - 4) / ((v_l / v_t)**2 + 2))
 name: belomestnikh_gruneisen
+implemented_by:
+- montoyjh
 references:
 - url:https://link.springer.com/article/10.1134/1.1666949
 symbol_property_map:

--- a/propnet/models/serialized/complex_refr_from_complex_perm.yaml
+++ b/propnet/models/serialized/complex_refr_from_complex_perm.yaml
@@ -15,6 +15,8 @@ equations:
 - n = sqrt((sqrt(e1**2+e2**2)+e1)/2)
 - k = sqrt((sqrt(e1**2+e2**2)-e1)/2)
 name: complex_refr_from_complex_perm
+implemented_by:
+- vtshitoyan
 references:
 - url:https://en.wikipedia.org/wiki/Refractive_index#Complex_refractive_index
 symbol_property_map:

--- a/propnet/models/serialized/debye_temperature.yaml
+++ b/propnet/models/serialized/debye_temperature.yaml
@@ -34,6 +34,8 @@ description: 'Assuming a linear dispersion relationship between angular frequenc
 equations:
 - T = (6*3.14159**2*p*1E10**3*v**3)**(1/3) * 6.626E-34/2/3.14159 / 1.38E-23
 name: debye_temperature
+implemented_by:
+- mkhorton
 references: []
 scrub_units: true
 symbol_property_map:

--- a/propnet/models/serialized/dielectric_figure_of_merit_current_leakage.yaml
+++ b/propnet/models/serialized/dielectric_figure_of_merit_current_leakage.yaml
@@ -18,6 +18,8 @@ description: 'Relation from Yim, K. et al. Novel high-\u03BA dielectrics for nex
 equations:
 - c = epsilon*E_g
 name: dielectric_figure_of_merit_current_leakage
+implemented_by:
+- dmrdjenovich
 references: []
 scrub_units: true
 symbol_property_map:

--- a/propnet/models/serialized/dielectric_figure_of_merit_energy.yaml
+++ b/propnet/models/serialized/dielectric_figure_of_merit_energy.yaml
@@ -20,6 +20,8 @@ description: 'Relation from Yim, K. et al. Novel high-\u03BA dielectrics for nex
 equations:
 - c = epsilon**(1/2)*E_g
 name: dielectric_figure_of_merit_energy
+implemented_by:
+- dmrdjenovich
 references: []
 scrub_units: true
 symbol_property_map:

--- a/propnet/models/serialized/el_resistivityfrom_el_conductivity.yaml
+++ b/propnet/models/serialized/el_resistivityfrom_el_conductivity.yaml
@@ -8,6 +8,8 @@ description: 'The electrical resistivity and conductivity are related by a simpl
 equations:
 - sigma = 1/rho
 name: el_resistivityfrom_el_conductivity
+implemented_by:
+- lweston
 references:
 - url:https://en.wikipedia.org/wiki/Electrical_resistivity_and_conductivity
 solve_for_all_symbols: true

--- a/propnet/models/serialized/empirical_band_gap_setyawan.yaml
+++ b/propnet/models/serialized/empirical_band_gap_setyawan.yaml
@@ -6,6 +6,8 @@ description: |
     against 100 compounds with gaps between ~1 and ~12 eV).
 equations: [E_g_expt = 1.348*E_g_pbe + 0.913]
 name: empirical_band_gap_setyawan
+implemented_by:
+- mkhorton
 references: ["doi:10.1021/co200012w"]
 symbol_property_map:
   E_g_expt: band_gap

--- a/propnet/models/serialized/empirical_band_gaps_garcia_gw.yaml
+++ b/propnet/models/serialized/empirical_band_gaps_garcia_gw.yaml
@@ -5,6 +5,8 @@ description: |
 equations:
     - E_g_expt = 0.998*E_g_GW + 0.014
 name: empirical_band_gaps_garcia_gw
+implemented_by:
+- mkhorton
 references: ["doi:10.1021/acs.jpcc.7b07421"]
 symbol_property_map:
   E_g_GW: band_gap_gw

--- a/propnet/models/serialized/empirical_band_gaps_garcia_pbe.yaml
+++ b/propnet/models/serialized/empirical_band_gaps_garcia_pbe.yaml
@@ -5,6 +5,8 @@ description: |
 equations:
     - E_g_expt = 1.358*E_g_pbe + 0.904
 name: empirical_band_gaps_garcia_pbe
+implemented_by:
+- mkhorton
 references: ["doi:10.1021/acs.jpcc.7b07421"]
 symbol_property_map:
   E_g_pbe: band_gap_pbe

--- a/propnet/models/serialized/empirical_band_gaps_metal_conversion.yaml
+++ b/propnet/models/serialized/empirical_band_gaps_metal_conversion.yaml
@@ -5,6 +5,8 @@ description: |
 equations:
     - E_g = E_g_pbe
 name: empirical_band_gaps_metal_conversion
+implemented_by:
+- montoyjh
 references: []
 symbol_property_map:
   E_g_pbe: band_gap_pbe

--- a/propnet/models/serialized/heat_capacity_conversion.yaml
+++ b/propnet/models/serialized/heat_capacity_conversion.yaml
@@ -6,6 +6,8 @@ description: 'simple conversion formula for specific and molar mass
 equations:
 - c_v_specific = c_v_molar / molar_mass
 name: heat_capacity_conversion
+implemented_by:
+- jdagdelen
 references: []
 solve_for_all_symbols: true
 symbol_property_map:

--- a/propnet/models/serialized/interatomic_spacing_average.yaml
+++ b/propnet/models/serialized/interatomic_spacing_average.yaml
@@ -8,6 +8,8 @@ description: 'Simple approximation for interatomic spacing as cube root of volum
 equations:
 - d = (p)**(-1/3)
 name: interatomic_spacing_average
+implemented_by:
+- montoyjh
 references: null
 symbol_property_map:
   d: interatomic_spacing

--- a/propnet/models/serialized/loss_function_from_complex_perm.yaml
+++ b/propnet/models/serialized/loss_function_from_complex_perm.yaml
@@ -8,6 +8,8 @@ description: 'The optical loss function derived from real and imaginary parts of
 equations:
 - l = e2**2/(e1**2+e2**2)
 name: loss_function_from_complex_perm
+implemented_by:
+- vtshitoyan
 references:
 - url:https://onlinelibrary.wiley.com/doi/abs/10.1002/pssb.2221630145
 - url:https://onlinelibrary.wiley.com/doi/abs/10.1002/pssb.2221630145

--- a/propnet/models/serialized/melting_point_from_lindemann_criterion.yaml
+++ b/propnet/models/serialized/melting_point_from_lindemann_criterion.yaml
@@ -6,6 +6,8 @@ equations:
 # Note that the Lindemann criterion is set to a default value of 0.15. Perhaps later can explore deriving it, if of interest.
 - T_m = 2 * pi * (mbar*1.66054e-27) * (0.15)**2 * (a*1e-10)**2 * T**2 * 1.38064852e-23 / ((6.62607004e-34)**2)
 name: melting_point_from_lindemann_criterion
+implemented_by:
+- clegaspi
 references:
   - doi:10.1063/1.2737054
   - doi:10.1103/PhysRevB.22.3790

--- a/propnet/models/serialized/optical_absorbance.yaml
+++ b/propnet/models/serialized/optical_absorbance.yaml
@@ -19,6 +19,8 @@ description: 'Absorbance A quantifies the reduction of light intensity as it pas
 equations:
 - A = (1 - R) * (1 - exp(-alpha * t))
 name: optical_absorbance
+implemented_by:
+- vtshitoyan
 references:
 - url:https://unlcms.unl.edu/cas/physics/tsymbal/teaching/SSP-927/Section%2013_Optical_Properties_of_Solids.pdf
 scrub_units: true

--- a/propnet/models/serialized/optical_absorption_coefficient.yaml
+++ b/propnet/models/serialized/optical_absorption_coefficient.yaml
@@ -14,6 +14,8 @@ description: 'Absorption coefficient characterizes the decay of intensity as lig
 equations:
 - alpha = (4*pi*k / l)
 name: optical_absorption_coefficient
+implemented_by:
+- vtshitoyan
 references:
 - url:https://en.wikipedia.org/wiki/Refractive_index#Complex_refractive_index
 - url:https://unlcms.unl.edu/cas/physics/tsymbal/teaching/SSP-927/Section%2013_Optical_Properties_of_Solids.pdf

--- a/propnet/models/serialized/optical_reflectance.yaml
+++ b/propnet/models/serialized/optical_reflectance.yaml
@@ -9,6 +9,8 @@ description: 'Reflectance R at the vacuum/material interface using real and imag
 equations:
 - R = ((1-n)**2+k**2)/((1+n)**2+k**2)
 name: optical_reflectance
+implemented_by:
+- vtshitoyan
 references:
 - url:https://unlcms.unl.edu/cas/physics/tsymbal/teaching/SSP-927/Section%2013_Optical_Properties_of_Solids.pdf
 symbol_property_map:

--- a/propnet/models/serialized/optical_transmittance.yaml
+++ b/propnet/models/serialized/optical_transmittance.yaml
@@ -13,6 +13,8 @@ description: 'Transmittance T is the portion of the transmitted intencity of the
 equations:
 - 1 = A + T + R
 name: optical_transmittance
+implemented_by:
+- vtshitoyan
 references: []
 solve_for_all_symbols: true
 symbol_property_map:

--- a/propnet/models/serialized/peierls_stress.yaml
+++ b/propnet/models/serialized/peierls_stress.yaml
@@ -8,6 +8,8 @@ description: 'Peierls stress is the force required to move a dislocation within
 equations:
 - T_pn = G*2.7182818285**(-2*3.14159*a/(1-nu)/b)
 name: peierls_stress
+implemented_by:
+- jpalakapilly
 references:
 - url:https://en.wikipedia.org/wiki/Peierls_stress}
 symbol_property_map:

--- a/propnet/models/serialized/pugh_ratio.yaml
+++ b/propnet/models/serialized/pugh_ratio.yaml
@@ -9,6 +9,8 @@ description: 'Model calculating the Pugh ratio (an indicator of ductility) from 
 equations:
 - k = B/G
 name: pugh_ratio
+implemented_by:
+- dmrdjenovich
 references: []
 symbol_property_map:
   B: bulk_modulus

--- a/propnet/models/serialized/refractive_indexfrom_rel_perm.yaml
+++ b/propnet/models/serialized/refractive_indexfrom_rel_perm.yaml
@@ -20,6 +20,8 @@ description: 'The refractive index gives the factor by which the speed of light 
 equations:
 - n = sqrt(Ur*Er)
 name: refractive_indexfrom_rel_perm
+implemented_by:
+- jpalakapilly
 references:
 - url:https://en.wikipedia.org/wiki/Refractive_index#Relative_permittivity_and_permeability}
 solve_for_all_symbols: true

--- a/propnet/models/serialized/schmids_law.yaml
+++ b/propnet/models/serialized/schmids_law.yaml
@@ -10,6 +10,8 @@ description: 'Schmid''''s Law states that the critically resolved shear stress i
 equations:
 - tau = m * sigma
 name: schmids_law
+implemented_by:
+- jpalakapilly
 references:
 - url:https://en.wikipedia.org/wiki/Schmid%27s_law
 solve_for_all_symbols: true

--- a/propnet/models/serialized/semi_empirical_mobility.yaml
+++ b/propnet/models/serialized/semi_empirical_mobility.yaml
@@ -17,6 +17,8 @@ description: 'The electron mobility is difficult to model purely from first prin
 equations:
 - mu_e = 1E9 * 1E4 * 1.2E-14 * K**1 * m_e**-1.5
 name: semi_empirical_mobility
+implemented_by:
+- lweston
 references:
 - doi:10.1039/C4EE03157A
 scrub_units: true

--- a/propnet/models/serialized/slack_equation.yaml
+++ b/propnet/models/serialized/slack_equation.yaml
@@ -12,6 +12,8 @@ equations:
 - k = (2.43*10**-8/ (1 - 0.514 / y + 0.228 / y**2)) * mbar * t_d**3 * d / (y**2 *
   n**(2/3) * T)
 name: slack_equation
+implemented_by:
+- montoyjh
 references:
   - doi:10.1007/0-387-25100-6_2
   - doi:10.1002/adfm.201600718

--- a/propnet/models/serialized/sound_velocity_elastic_longitudinal.yaml
+++ b/propnet/models/serialized/sound_velocity_elastic_longitudinal.yaml
@@ -10,6 +10,8 @@ description: 'The sound velocity from the elastic modulus is determined by
 equations:
 - v_l = ((B+4/3*G)/p)**(1/2)
 name: sound_velocity_elastic_longitudinal
+implemented_by:
+- dmrdjenovich
 references: []
 scrub_units:
   B: Pa

--- a/propnet/models/serialized/sound_velocity_elastic_mean.yaml
+++ b/propnet/models/serialized/sound_velocity_elastic_mean.yaml
@@ -10,6 +10,8 @@ description: 'The sound velocity from the elastic modulus is determined by
 equations:
 - v_m = (1/3*(2/v_t**3 + 1/v_l**3))**(-1/3)
 name: sound_velocity_elastic_mean
+implemented_by:
+- dmrdjenovich
 references: []
 symbol_property_map:
   v_l: sound_velocity_longitudinal

--- a/propnet/models/serialized/sound_velocity_elastic_transverse.yaml
+++ b/propnet/models/serialized/sound_velocity_elastic_transverse.yaml
@@ -10,6 +10,8 @@ description: 'The sound velocity from the elastic modulus is determined by
 equations:
 - v_t = (G/p)**(1/2)
 name: sound_velocity_elastic_transverse
+implemented_by:
+- dmrdjenovich
 references: []
 scrub_units:
   B: Pa

--- a/propnet/models/serialized/thermal_expansion_from_gruneisen.yaml
+++ b/propnet/models/serialized/thermal_expansion_from_gruneisen.yaml
@@ -10,6 +10,8 @@ description: 'An expression for the thermal expansion of a solid from density, c
 equations:
 - a = y * c_v * p / k
 name: thermal_expansion_from_gruneisen
+implemented_by:
+- montoyjh
 references:
 - url:https://en.wikipedia.org/wiki/Gr%C3%BCneisen_parameter
 solve_for_all_symbols: true

--- a/propnet/models/serialized/vickers_hardness_chen.yaml
+++ b/propnet/models/serialized/vickers_hardness_chen.yaml
@@ -9,6 +9,8 @@ description: 'Model calculating the Vicker''''s Hardness from bulk and shear mod
 equations:
 - H = 2*(G/k**2)**0.585 - 3
 name: vickers_hardness_chen
+implemented_by:
+- dmrdjenovich
 references: []
 scrub_units: true
 symbol_property_map:

--- a/propnet/models/serialized/vickers_hardness_tian.yaml
+++ b/propnet/models/serialized/vickers_hardness_tian.yaml
@@ -9,6 +9,8 @@ description: 'Model calculating the Vicker''''s Hardness from bulk and shear mod
 equations:
 - H = 0.92*(1/k)**1.137*G**0.708
 name: vickers_hardness_tian
+implemented_by:
+- dmrdjenovich
 references: []
 scrub_units: true
 symbol_property_map:

--- a/propnet/models/serialized/wiedemann_franz_law.yaml
+++ b/propnet/models/serialized/wiedemann_franz_law.yaml
@@ -34,6 +34,8 @@ description: 'The Wiedemann-Franz Law states that the ratio of the
 equations:
 - k = T * 2.45*10**-8 * o
 name: wiedemann_franz_law
+implemented_by:
+- jpalakapilly
 references:
 - url:http://hyperphysics.phy-astr.gsu.edu/hbase/thermo/thercond.html#c2
 scrub_units: true

--- a/propnet/models/staging/goldschmidt_tolerance.yaml
+++ b/propnet/models/staging/goldschmidt_tolerance.yaml
@@ -7,6 +7,8 @@ description: |
   It can be reliably used as a metric in perovskites and ilmenites.
 equations: [t = (r_cation_A + r_anion)/(2**.5 * (r_cation_B + r_anion))]
 name: goldschmidt_tolerance
+implemented_by:
+- jpalakapilly
 references: []
 symbol_property_map:
   r_anion: ionic_radius


### PR DESCRIPTION
The `implemented_by` field is a list of github usernames, whose info can be pulled from the github API eventually. In response to issue #160 

Authorship was assigned to current models based on who first authored the model or its predecessor in the code. It should be accurate, but please suggest changes if there are inaccuracies.