### PR TITLE
Fix uncaught copy-paste error in quantity constructor

### DIFF
--- a/propnet/core/quantity.py
+++ b/propnet/core/quantity.py
@@ -79,7 +79,7 @@ class Quantity(MSONable):
             self._value = value
 
         if isinstance(uncertainty, (float, int, list, np.ndarray)):
-            self._uncertainty = ureg.Quantity(value, units)
+            self._uncertainty = ureg.Quantity(uncertainty, units)
         elif isinstance(uncertainty, ureg.Quantity):
             self._uncertainty = uncertainty.to(units)
         else:


### PR DESCRIPTION
Currently, the constructor creates a `Quantity` for `self.uncertainty` using the passed-in argument `value` instead of `uncertainty` (when `uncertainty` is passed in as an int/float).

This fixes that typo. Perhaps should push it to the website?