### PR TITLE
Fix unit mapping for test data

### DIFF
--- a/propnet/core/models.py
+++ b/propnet/core/models.py
@@ -96,7 +96,9 @@ class Model(ABC):
             else:
                 self.constraints.append(Constraint(constraint))
 
-        self._test_data = test_data or self.load_test_data()
+        # Ensures our test data is symbol-keyed
+        self._test_data = [{k: self.map_properties_to_symbols(v) for k, v in data.items()}
+                           for data in test_data or self.load_test_data()]
 
     @abstractmethod
     def plug_in(self, symbol_value_dict):
@@ -307,9 +309,8 @@ class Model(ABC):
 
         Returns (bool): True if test succeeds
         """
-        evaluate_inputs = self.map_symbols_to_properties(inputs)
         evaluate_inputs = {s: Quantity(s, v, self.unit_map.get(s))
-                           for s, v in evaluate_inputs.items()}
+                           for s, v in inputs.items()}
         evaluate_outputs = self.evaluate(evaluate_inputs, allow_failure=False)
         evaluate_outputs = self.map_properties_to_symbols(evaluate_outputs)
         errmsg = "{} model test failed on ".format(self.name) + "{}\n"

--- a/propnet/core/models.py
+++ b/propnet/core/models.py
@@ -312,8 +312,10 @@ class Model(ABC):
 
         Returns (bool): True if test succeeds
         """
-        evaluate_inputs = {s: Quantity(s, v, self.unit_map.get(s))
-                           for s, v in inputs.items()}
+        evaluate_inputs = self.map_symbols_to_properties(inputs)
+        unit_map_as_properties = self.map_symbols_to_properties(self.unit_map)
+        evaluate_inputs = {s: Quantity(s, v, unit_map_as_properties.get(s))
+                           for s, v in evaluate_inputs.items()}
         evaluate_outputs = self.evaluate(evaluate_inputs, allow_failure=False)
         evaluate_outputs = self.map_properties_to_symbols(evaluate_outputs)
         errmsg = "{} model test failed on ".format(self.name) + "{}\n"

--- a/propnet/core/models.py
+++ b/propnet/core/models.py
@@ -97,8 +97,11 @@ class Model(ABC):
                 self.constraints.append(Constraint(constraint))
 
         # Ensures our test data is symbol-keyed
-        self._test_data = [{k: self.map_properties_to_symbols(v) for k, v in data.items()}
-                           for data in test_data or self.load_test_data()]
+        test_data = test_data or self.load_test_data()
+        if test_data:
+            test_data = [{k: self.map_properties_to_symbols(v) for k, v in data.items()}
+                         for data in test_data]
+        self._test_data = test_data
 
     @abstractmethod
     def plug_in(self, symbol_value_dict):

--- a/propnet/models/serialized/sound_velocity_elastic_longitudinal.yaml
+++ b/propnet/models/serialized/sound_velocity_elastic_longitudinal.yaml
@@ -25,8 +25,8 @@ symbol_property_map:
   v_l: sound_velocity_longitudinal
 test_data:
 - inputs:
-    B: 182.33333333333337
-    G: 73.44285714285714
-    p: 8.027685486298079
+    B: 1.8233333333333337e11
+    G: 7.344285714285714e10
+    p: 8.027685486298079e3
   outputs:
     v_l: 5908.5806864576425

--- a/propnet/models/serialized/sound_velocity_elastic_transverse.yaml
+++ b/propnet/models/serialized/sound_velocity_elastic_transverse.yaml
@@ -24,7 +24,7 @@ symbol_property_map:
   v_t: sound_velocity_transverse
 test_data:
 - inputs:
-    G: 73.44285714285714
-    p: 8.027685486298079
+    G: 7.344285714285714e10
+    p: 8.027685486298079e3
   outputs:
     v_t: 3024.6812029245752


### PR DESCRIPTION
- `Model.test()` now does not try to map symbols to properties before looking for units in the unit map (which is symbol-keyed).
- Users can now key their test data in the yaml file by symbol or property, and the keys will be coerced to symbols upon model instantiation