### PR TITLE
Change out deprecated pymatgen functions

### DIFF
--- a/propnet/models/python/dimensionality_cheon.py
+++ b/propnet/models/python/dimensionality_cheon.py
@@ -1,10 +1,10 @@
-from pymatgen.analysis.find_dimension import find_dimension
+from pymatgen.analysis.dimensionality import get_dimensionality_cheon
 
 
 def plug_in(symbol_values):
     structure = symbol_values['structure']
     return {
-        'dimensionality': find_dimension(structure),
+        'dimensionality': get_dimensionality_cheon(structure),
     }
 
 DESCRIPTION = """

--- a/propnet/models/python/dimensionality_gorai.py
+++ b/propnet/models/python/dimensionality_gorai.py
@@ -1,10 +1,10 @@
-from pymatgen.analysis.structure_analyzer import get_dimensionality
+from pymatgen.analysis.dimensionality import get_dimensionality_gorai
 
 
 def plug_in(symbol_values):
     structure = symbol_values['structure']
     return {
-        'dimensionality': get_dimensionality(structure)
+        'dimensionality': get_dimensionality_gorai(structure)
     }
 
 DESCRIPTION = """


### PR DESCRIPTION
Changed out Gorai and Cheon functions for dimensionality for their new location in the pymatgen package.

I was tired of all the deprecation warnings mucking up the tests.