### PR TITLE
Replace mp-dash-components dependencies with crystal-toolkit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,10 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy
   - source activate test-environment
   - pip install -r requirements.txt
   - conda install pygraphviz
-  - conda install -c bioconda minepy
   - pip install nose
   - pip install coverage
   - pip install python-coveralls

--- a/propnet/web/app.py
+++ b/propnet/web/app.py
@@ -13,7 +13,7 @@ from propnet.web.layouts_home import home_layout
 from propnet.web.layouts_interactive import interactive_layout
 from propnet.web.layouts_explore import explore_layout
 
-from mp_dash_components import GraphComponent
+from crystal_toolkit import GraphComponent
 
 from propnet.web.utils import parse_path
 

--- a/propnet/web/layouts_explore.py
+++ b/propnet/web/layouts_explore.py
@@ -4,7 +4,7 @@ import dash_html_components as html
 from dash.dependencies import Input, Output, State
 from dash.exceptions import PreventUpdate
 
-from mp_dash_components import GraphComponent
+from crystal_toolkit import GraphComponent
 from propnet.web.utils import graph_conversion, AESTHETICS
 from propnet.core.graph import Graph
 

--- a/propnet/web/layouts_interactive.py
+++ b/propnet/web/layouts_interactive.py
@@ -2,7 +2,7 @@ import dash_core_components as dcc
 import dash_html_components as html
 import dash_table_experiments as dt
 
-from mp_dash_components import GraphComponent
+from crystal_toolkit import GraphComponent
 from propnet.web.utils import graph_conversion, AESTHETICS
 
 import json

--- a/propnet/web/layouts_models.py
+++ b/propnet/web/layouts_models.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 import dash_html_components as html
 import dash_core_components as dcc
-from mp_dash_components import GraphComponent
+from crystal_toolkit import GraphComponent
 
 import networkx as nx
 from propnet.core.graph import Graph

--- a/propnet/web/layouts_symbols.py
+++ b/propnet/web/layouts_symbols.py
@@ -1,6 +1,6 @@
 import dash_html_components as html
 import dash_core_components as dcc
-from mp_dash_components import GraphComponent
+from crystal_toolkit import GraphComponent
 from pydash import set_
 
 import networkx as nx

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,10 +21,12 @@ Flask-Caching==1.3.3
 uncertainties==3.0.2
 maggma>=0.11.0
 gbml>=1.1.0
-mp_dash_components>=0.0.2
+crystal-toolkit>=0.0.1
 scikit-learn>=0.20.0
 chronic>=0.3.4
 matminer>=0.4.3
 pandas>=0.23.4
 scipy>=1.0.1
+sympy>=1.3
+minepy>=1.2.3
 -e .


### PR DESCRIPTION
Until we overhaul the network graph, a hotfix for replacing removed package mp-dash-components.