### PR TITLE
Separate built-in models and symbols from core infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ install:
   - pip install coverage
   - pip install python-coveralls
 script:
-  - nosetests --with-coverage --cover-package=propnet
+  - nosetests ./ docs/ --with-coverage --cover-package=propnet
 after_success:
   - coveralls

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,17 @@ apidoc_excluded_paths = ['../propnet/models/python/[!_]*.py',
                          '../propnet/web']
 apidoc_separate_modules = True
 
+
+# Configure autodoc to not skip __init__() functions
+def skip(app, what, name, obj, would_skip, options):
+    if name == "__init__":
+        return False
+    return would_skip
+
+
+def setup(app):
+    app.connect("autodoc-skip-member", skip)
+
 # Napoleon config
 napoleon_google_docstring = True
 

--- a/docs/tests/test_doc_build.py
+++ b/docs/tests/test_doc_build.py
@@ -1,0 +1,25 @@
+import unittest
+from sphinx.cmd.build import build_main
+import os
+import shutil
+
+
+class DocBuildTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.docs_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        cls.html_path = os.path.join(cls.docs_path, '_build', 'html')
+        shutil.rmtree(cls.html_path, ignore_errors=True)
+
+    '''
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.html_path, ignore_errors=True)
+    '''
+
+    def test_build_docs(self):
+        build_main(argv=['-b', 'html', self.docs_path, self.html_path])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/propnet/core/graph.py
+++ b/propnet/core/graph.py
@@ -23,10 +23,6 @@ from propnet.core.provenance import SymbolTree, TreeElement
 from propnet.symbols import Symbol
 from propnet.core.utils import Timeout
 
-# noinspection PyUnresolvedReferences
-import propnet.models
-# noinspection PyUnresolvedReferences
-import propnet.symbols
 from propnet.core.registry import Registry
 
 from typing import Set, Dict, Union

--- a/propnet/core/models.py
+++ b/propnet/core/models.py
@@ -1139,7 +1139,7 @@ class Constraint(Model):
                 raise KeyError("Symbol '{}' is not registered in "
                                "symbol registry for constraint '{}'.".format(prop, self.expression))
 
-    def register(self, **kwargs):
+    def register(self, overwrite_registry=True):
         pass
 
     def plug_in(self, symbol_value_dict):

--- a/propnet/core/models.py
+++ b/propnet/core/models.py
@@ -1,5 +1,5 @@
 """
-Module containing classes and methods for Model functionality in Propnet code.
+Module containing classes and methods for Model functionality in propnet code.
 """
 
 import os
@@ -33,36 +33,36 @@ TEST_DATA_LOC = os.path.join(os.path.dirname(__file__), "..",
 
 class Model(ABC):
     """
-    Abstract model class for all models appearing in Propnet
+    Abstract model class for all models appearing in propnet
 
     Args:
         name (str): title of the model
-        connections ([dict]): list of connections dictionaries, which take
-            the form {"inputs": [Symbols], "outputs": [Symbols]}, e. g.:
-            connections = [{"inputs": ["p", "T"], "outputs": ["V"]},
-                           {"inputs": ["T", "V"], "outputs": ["p"]}]
-        constraints ([str or Constraint]): string expressions or
+        connections (`list` of `dict`): list of connections dictionaries, which take
+            the form ``{"inputs": [Symbols], "outputs": [Symbols]}``, e. g.:
+            ``connections = [{"inputs": ["p", "T"], "outputs": ["V"]},``
+            ``{"inputs": ["T", "V"], "outputs": ["p"]}]``
+        constraints (str, Constraint): string expressions or
             Constraint objects of some condition on which the model is
-            valid, e. g. "n > 0", note that this must include symbols if
+            valid, e. g. ``"n > 0"``, note that this must include symbols if
             there is a symbol_property_map
         description (str): long form description of the model
-        categories ([str]): list of categories applicable to
+        categories (`list` of `str`): list of categories applicable to
             the model
-        references ([str]): list of the informational links
+        references (`list` of `str`): list of the informational links
             explaining / supporting the model
-        implemented_by ([str]): list of authors of the model by their
+        implemented_by (`list` of `str`): list of authors of the model by their
             github usernames
-        symbol_property_map ({str: str}): mapping of symbols enumerated
+        symbol_property_map (dict): \{`str`\: `str`} - mapping of symbols enumerated
             in the plug-in method to canonical symbols, e. g.
-            {"n": "index_of_refraction"} etc.
-        units_for_evaluation (bool or {str: str}): whether or not units should
-            be scrubbed in evaluation procedure, if a boolean is specified,
+            ``{"n": "index_of_refraction"}`` etc.
+        units_for_evaluation (`str`, `dict`: {`str`: `str`}): whether or not units should
+            be scrubbed in evaluation procedure, if the string ``'default'`` is specified,
             quantities are converted to default units before scrubbing, if
             a dict, quantities are specified to units corresponding to the
             unit assigned to the symbol in the dicts.  Units are scrubbed
             by default for PyModels/PyModule models and EquationModels with
             'empirical' categories
-        test_data (list of {'inputs': [], 'outputs': []): test data with
+        test_data (list of {'inputs': [], 'outputs': []}): test data with
             which to evaluate the model
         is_builtin (bool): True if the model is a default model included with propnet
             (this option not intended to be set by users)
@@ -124,19 +124,53 @@ class Model(ABC):
             self.register(overwrite_registry=overwrite_registry)
 
     def register(self, overwrite_registry=True):
+        """
+        Registers the model with the appropriate model registry.
+
+        Args:
+            overwrite_registry (bool): If a model with the same name
+                as the current is already registered, `True` will overwrite
+                the old model with the current and `False` will raise a
+                KeyError.
+
+        Raises:
+            KeyError: if `overwrite_registry=False` and a model with the same
+                name is already registered, this error is raised.
+
+        """
         if not overwrite_registry and self.name in Registry(self._registry_name).keys():
             raise KeyError("Model '{}' already exists in the registry '{}'".format(self.name,
                                                                                    self._registry_name))
         Registry(self._registry_name)[self.name] = self
 
     def unregister(self):
+        """
+        Removes the symbol from all applicable registries.
+
+        """
         Registry(self._registry_name).pop(self.name, None)
 
     @property
     def registered(self):
+        """
+        Indicates if a model is registered with the model registry.
+
+        Returns:
+            bool: True if the model is registered. False otherwise.
+
+        """
         return self.name in Registry(self._registry_name)
 
     def _clean_test_data(self, test_data):
+        """
+        Coerces test data into a value-unit format.
+
+        Args:
+            test_data (`list` of `dict`): structured test data (see ``__init__()``)
+
+        Returns:
+            `list` of `dict`: test data converted to the value-unit format
+        """
         clean_test_data = []
         for io_data_set in test_data:
             clean_data_set = {}
@@ -167,13 +201,27 @@ class Model(ABC):
         return clean_test_data
 
     def _verify_properties_are_registered(self):
+        """
+        Ensures that all Symbol names associated with this model are
+        registered in the symbol registry.
+
+        Raises:
+            KeyError: if a symbol is not registered, this error is raised
+        """
         for prop in self.all_properties:
-            if prop not in Registry("symbols").keys():
+            if prop not in Registry("symbols"):
                 raise KeyError("Symbol '{}' is not registered in "
                                "symbol registry in model '{}'.".format(prop, self.name))
 
     @property
     def is_builtin(self):
+        """
+        Indicates whether the model is a propnet built-in.
+
+        Returns:
+            bool: ``True`` if the model is a built-in, ``False``
+                if it is a custom-created model
+        """
         return self._is_builtin
 
     @property

--- a/propnet/core/models.py
+++ b/propnet/core/models.py
@@ -928,6 +928,11 @@ class CompositeModel(PyModel):
                                                                        material_type,
                                                                        self.name))
 
+    def register(self, overwrite_registry=True):
+        if not overwrite_registry and self.name in Registry("composite_models").keys():
+            raise KeyError("Model '{}' already exists in the composite model registry".format(self.name))
+        Registry("composite_models")[self.name] = self
+
     @staticmethod
     def get_material(input_):
         """

--- a/propnet/core/symbols.py
+++ b/propnet/core/symbols.py
@@ -311,8 +311,18 @@ class Symbol(MSONable):
         return safe_dump(data)
 
     def as_dict(self):
-        d = super().as_dict()
-        if self.units:
-            d['units'] = (1 * d['units']).to_tuple()
+        d = {'@module': self.__module__,
+             '@class': self.__class__.__name__,
+             'name': self.name,
+             'display_names': self.display_names,
+             'display_symbols': self.display_symbols,
+             'units': (1 * self.units).to_tuple() if self.units else None,
+             'shape': self.shape,
+             'object_type': self.object_type,
+             'comment': self.comment,
+             'category': self.category,
+             'constraint': self.constraint,
+             'default_value': self.default_value,
+             'is_builtin': self._is_builtin}
 
         return d

--- a/propnet/core/symbols.py
+++ b/propnet/core/symbols.py
@@ -45,13 +45,13 @@ class Symbol(MSONable):
         Args:
             name (str): string ASCII identifying the property uniquely
                 as an internal identifier.
-            units (str or tuple): units of the property as a Quantity
+            units (str, tuple): units of the property as a Quantity
                 supported by the Pint package.  Can be supplied as a
                 string (e. g. cm^2) or a tuple for Quantity.from_tuple
                 (e. g. [1.0, [['centimeter', 1.0]]])
-            display_names (list<str>): list of strings giving possible
+            display_names (:obj:`list` of :obj:`str`): list of strings giving possible
                 human-readable names for the property.
-            display_symbols (list<str>): list of strings giving possible
+            display_symbols (:obj:`list` of :obj:`str`): list of strings giving possible
                 human-readable symbols for the property.
             shape (id): list giving the order of the tensor as the length,
                 and number of dimensions as individual integers in the list.
@@ -69,6 +69,7 @@ class Symbol(MSONable):
                 temperature or 1 for magnetic permeability
             is_builtin (bool): True if the model is included with propnet
                 by default. Not intended to be set explicitly by users
+            register (bool): Test
         """
 
         # TODO: not sure object should be distinguished
@@ -171,22 +172,22 @@ class Symbol(MSONable):
 
     def register(self, overwrite_registry=False):
         if not overwrite_registry and \
-                (self in Registry("symbols").keys() or self in Registry("units").keys()):
+                (self.name in Registry("symbols").keys() or self.name in Registry("units").keys()):
             raise KeyError("Symbol '{}' already exists in the symbol or unit registry".format(self.name))
 
-        Registry("symbols")[self] = self
-        Registry("units")[self] = self.units.format_babel() if self.units else None
+        Registry("symbols")[self.name] = self
+        Registry("units")[self.name] = self.units.format_babel() if self.units else None
         if self.default_value is not None:
-            Registry("symbol_values")[self] = self.default_value
+            Registry("symbol_values")[self.name] = self.default_value
 
     def unregister(self):
-        Registry("symbols").pop(self, None)
-        Registry("units").pop(self, None)
-        Registry("symbol_values").pop(self, None)
+        Registry("symbols").pop(self.name, None)
+        Registry("units").pop(self.name, None)
+        Registry("symbol_values").pop(self.name, None)
 
     @property
     def registered(self):
-        return self in Registry("symbols").keys()
+        return self.name in Registry("symbols").keys()
 
     @property
     def constraint(self):

--- a/propnet/core/symbols.py
+++ b/propnet/core/symbols.py
@@ -35,7 +35,7 @@ class Symbol(MSONable):
     def __init__(self, name, display_names=None, display_symbols=None,
                  units=None, shape=None, object_type=None, comment=None,
                  category='property', constraint=None, default_value=None,
-                 is_builtin=False, register=True, overwrite_registry=False):
+                 is_builtin=False, register=True, overwrite_registry=True):
         """
         Parses and validates a series of inputs into a PropertyMetadata
         tuple, a format that PropNet expects.

--- a/propnet/core/symbols.py
+++ b/propnet/core/symbols.py
@@ -35,7 +35,7 @@ class Symbol(MSONable):
     def __init__(self, name, display_names=None, display_symbols=None,
                  units=None, shape=None, object_type=None, comment=None,
                  category='property', constraint=None, default_value=None,
-                 is_builtin=False, overwrite_registry=True):
+                 is_builtin=False, register=True, overwrite_registry=False):
         """
         Parses and validates a series of inputs into a PropertyMetadata
         tuple, a format that PropNet expects.
@@ -166,12 +166,14 @@ class Symbol(MSONable):
         self._constraint = constraint
         self._constraint_func = None
 
+        if register:
+            self.register(overwrite_registry=overwrite_registry)
+
+    def register(self, overwrite_registry=False):
         if not overwrite_registry and \
                 (self in Registry("symbols").keys() or self in Registry("units").keys()):
             raise KeyError("Symbol '{}' already exists in the symbol or unit registry".format(self.name))
-        self.register()
 
-    def register(self):
         Registry("symbols")[self] = self
         Registry("units")[self] = self.units.format_babel() if self.units else None
         if self.default_value is not None:

--- a/propnet/core/symbols.py
+++ b/propnet/core/symbols.py
@@ -36,24 +36,23 @@ class Symbol(MSONable):
                  category='property', constraint=None, default_value=None,
                  is_builtin=False, register=True, overwrite_registry=True):
         """
-        Parses and validates a series of inputs into a PropertyMetadata
-        tuple, a format that PropNet expects.
-
-        Parameters correspond exactly with those of a PropertyMetadata tuple.
+        Instantiates Symbol object.
 
         Args:
             name (str): string ASCII identifying the property uniquely
                 as an internal identifier.
             units (str, tuple): units of the property as a Quantity
                 supported by the Pint package.  Can be supplied as a
-                string (e. g. cm^2) or a tuple for Quantity.from_tuple
-                (e. g. [1.0, [['centimeter', 1.0]]])
-            display_names (:obj:`list` of :obj:`str`): list of strings giving possible
+                string (e. g. ``cm^2``) or a tuple for ``Quantity.from_tuple``
+                (e. g. ``[1.0, [['centimeter', 1.0]]]``)
+            display_names (`list` of `str`): list of strings giving possible
                 human-readable names for the property.
-            display_symbols (:obj:`list` of :obj:`str`): list of strings giving possible
+            display_symbols (`list` of `str`): list of strings giving possible
                 human-readable symbols for the property.
-            shape (int, list): list giving the order of the tensor as the length,
+            shape (list, int): list giving the order of the tensor as the length,
                 and number of dimensions as individual integers in the list.
+                If an integer is provided, the symbol contains a vector. If ``shape=1``,
+                the symbol contains a scalar.
             comment (str): any useful information on the property including
                 its definitions and possible citations.
             category (str): 'property', for property of a material,
@@ -63,7 +62,7 @@ class Symbol(MSONable):
                 these symbols.
             constraint (str): constraint associated with the symbol, must
                 be a string expression (e. g. inequality) using the symbol
-                name, e. g. bulk_modulus > 0.
+                name, e. g. ``bulk_modulus > 0``.
             default_value (any): default value for the symbol, e. g. 300 for
                 temperature or 1 for magnetic permeability
             is_builtin (bool): True if the model is included with propnet
@@ -180,9 +179,9 @@ class Symbol(MSONable):
 
         Args:
             overwrite_registry (bool): If a symbol with the same name
-                as the current is already registered, True will overwrite
-                the old symbol with the current. False will raise a
-                KeyError if the name is present in the registry.
+                as the current is already registered, `True` will overwrite
+                the old symbol with the current and `False` will raise a
+                KeyError.
 
         Raises:
             KeyError: if `overwrite_registry=False` and a symbol with the same
@@ -220,6 +219,12 @@ class Symbol(MSONable):
 
     @property
     def constraint(self):
+        """
+        Gets callable constraint function for this symbol.
+
+        Returns:
+            callable: sympy lambda function representing the symbol constraint
+        """
         if self._constraint:
             if self._constraint_func is None:
                 self._constraint_func = sp.lambdify(self.name, parse_expr(self._constraint))
@@ -233,6 +238,13 @@ class Symbol(MSONable):
 
     @property
     def is_builtin(self):
+        """
+        Indicates whether the symbol is a propnet built-in.
+
+        Returns:
+            bool: ``True`` if the symbol is a built-in, ``False``
+                if it is a custom-created symbol
+        """
         return self._is_builtin
 
     @property
@@ -250,8 +262,10 @@ class Symbol(MSONable):
     @property
     def dimension_as_string(self):
         """
+        Produces the shape including form factor (scalar, vector, matrix, tensor)
+
         Returns:
-            (str): shape of property (np.shape) as a human-readable string
+            str: shape of property (np.shape) as a human-readable string
         """
 
         if isinstance(self.shape, int):
@@ -267,7 +281,10 @@ class Symbol(MSONable):
     @property
     def unit_as_string(self):
         """
-        Returns: unit of property as human-readable string
+        Produces units of the symbol as a human-readable string
+
+        Returns:
+            str: units
         """
 
         if self.units.dimensionless:
@@ -281,7 +298,10 @@ class Symbol(MSONable):
     @property
     def compatible_units(self):
         """
-        Returns: list of compatible units as strings
+        Gets a list of units with compatible dimensionality to the symbol's unit
+
+        Returns:
+            `list` of `str`: compatible units
         """
         try:
             compatible_units = [str(u) for u in self.units.compatible_units()]

--- a/propnet/core/symbols.py
+++ b/propnet/core/symbols.py
@@ -179,6 +179,15 @@ class Symbol(MSONable):
         if self.default_value is not None:
             Registry("symbol_values")[self] = self.default_value
 
+    def unregister(self):
+        Registry("symbols").pop(self, None)
+        Registry("units").pop(self, None)
+        Registry("symbol_values").pop(self, None)
+
+    @property
+    def registered(self):
+        return self in Registry("symbols").keys()
+
     @property
     def constraint(self):
         if self._constraint:

--- a/propnet/core/tests/test_fitting.py
+++ b/propnet/core/tests/test_fitting.py
@@ -8,20 +8,23 @@ from propnet.core.quantity import QuantityFactory
 from propnet.core.graph import Graph
 from propnet.core.materials import Material
 from propnet.core.provenance import ProvenanceElement
-
+from propnet.models import add_builtin_models_to_registry
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 
+
 class FittingTests(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
+        add_builtin_models_to_registry()
         path = os.path.join(TEST_DIR, "fitting_test_data.csv")
         test_data = pd.read_csv(path)
         graph = Graph()
         materials = [Material([QuantityFactory.create_quantity("band_gap", bg)])
                      for bg in test_data['band_gap']]
-        self.evaluated = [graph.evaluate(mat) for mat in materials]
-        self.benchmarks = [{"refractive_index": n}
-                           for n in test_data['refractive_index']]
+        cls.evaluated = [graph.evaluate(mat) for mat in materials]
+        cls.benchmarks = [{"refractive_index": n}
+                          for n in test_data['refractive_index']]
 
     def test_get_sse(self):
         mats = [Material([QuantityFactory.create_quantity("band_gap", n)]) for n in range(1, 5)]
@@ -57,6 +60,7 @@ class FittingTests(unittest.TestCase):
                                   models=model_names)
         self.assertAlmostEqual(
             scores['band_gap_refractive_index_herve_vandamme'], 1.371478, 3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/propnet/core/tests/test_graph.py
+++ b/propnet/core/tests/test_graph.py
@@ -14,8 +14,7 @@ import os
 import json
 from monty.json import MontyDecoder, jsanitize
 
-# noinspection PyUnresolvedReferences
-import propnet.symbols
+from propnet.models import add_builtin_models_to_registry
 from propnet.core.registry import Registry
 
 # TODO: I think the expansion/tree traversal methods are very cool
@@ -31,7 +30,9 @@ TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 class GraphTest(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
+        add_builtin_models_to_registry()
         symbols = GraphTest.generate_canonical_symbols()
         _ = GraphTest.generate_canonical_models()
 
@@ -61,35 +62,38 @@ class GraphTest(unittest.TestCase):
              QuantityFactory.create_quantity(symbols['F'], 322,
                                              provenance=ProvenanceElement(model='model3',
                                                                           inputs=[b[1]]))]
-        d_model4 = [QuantityFactory.create_quantity(symbols['D'], 23826,
-                                             provenance=ProvenanceElement(model='model4',
-                                                                          inputs=[b[0], c[0]])),
-             QuantityFactory.create_quantity(symbols['D'], 28842,
-                                             provenance=ProvenanceElement(model='model4',
-                                                                          inputs=[b[0], c[1]])),
-             QuantityFactory.create_quantity(symbols['D'], 28842,
-                                             provenance=ProvenanceElement(model='model4',
-                                                                          inputs=[b[1], c[0]])),
-             QuantityFactory.create_quantity(symbols['D'], 34914,
-                                             provenance=ProvenanceElement(model='model4',
-                                                                          inputs=[b[1], c[1]]))]
+        d_model4 = [
+            QuantityFactory.create_quantity(symbols['D'], 23826,
+                                            provenance=ProvenanceElement(model='model4',
+                                                                         inputs=[b[0], c[0]])),
+            QuantityFactory.create_quantity(symbols['D'], 28842,
+                                            provenance=ProvenanceElement(model='model4',
+                                                                         inputs=[b[0], c[1]])),
+            QuantityFactory.create_quantity(symbols['D'], 28842,
+                                            provenance=ProvenanceElement(model='model4',
+                                                                         inputs=[b[1], c[0]])),
+            QuantityFactory.create_quantity(symbols['D'], 34914,
+                                            provenance=ProvenanceElement(model='model4',
+                                                                         inputs=[b[1], c[1]]))]
 
-        d_model5 = [QuantityFactory.create_quantity(symbols['D'], 70395,
-                                             provenance=ProvenanceElement(model='model5',
-                                                                          inputs=[c[0], g[0]])),
-             QuantityFactory.create_quantity(symbols['D'], 85215,
-                                             provenance=ProvenanceElement(model='model5',
-                                                                          inputs=[c[0], g[1]])),
-             QuantityFactory.create_quantity(symbols['D'], 85215,
-                                             provenance=ProvenanceElement(model='model5',
-                                                                          inputs=[c[1], g[0]])),
-             QuantityFactory.create_quantity(symbols['D'], 103155,
-                                             provenance=ProvenanceElement(model='model5',
-                                                                          inputs=[c[1], g[1]]))]
-        self.expected_quantities = a + b + c + d_model4 + d_model5 + f + g
-        self.expected_constrained_quantities = a + b + c + d_model5 + f + g
+        d_model5 = [
+            QuantityFactory.create_quantity(symbols['D'], 70395,
+                                            provenance=ProvenanceElement(model='model5',
+                                                                         inputs=[c[0], g[0]])),
+            QuantityFactory.create_quantity(symbols['D'], 85215,
+                                            provenance=ProvenanceElement(model='model5',
+                                                                         inputs=[c[0], g[1]])),
+            QuantityFactory.create_quantity(symbols['D'], 85215,
+                                            provenance=ProvenanceElement(model='model5',
+                                                                         inputs=[c[1], g[0]])),
+            QuantityFactory.create_quantity(symbols['D'], 103155,
+                                            provenance=ProvenanceElement(model='model5',
+                                                                         inputs=[c[1], g[1]]))]
+        cls.expected_quantities = a + b + c + d_model4 + d_model5 + f + g
+        cls.expected_constrained_quantities = a + b + c + d_model5 + f + g
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         non_builtin_syms = [k for k, v in Registry("symbols").items() if not v.is_builtin]
         for sym in non_builtin_syms:
             Registry("symbols").pop(sym)
@@ -119,10 +123,6 @@ class GraphTest(unittest.TestCase):
             'G': G,
             'F': F
         }
-
-        for sym in syms.values():
-            Registry("symbols")[sym] = sym
-            Registry("units")[sym] = sym.units
 
         return syms
 
@@ -155,7 +155,6 @@ class GraphTest(unittest.TestCase):
 
         models = [model1, model2, model3, model4, model5, model6]
         models_dict = {x.name: x for x in models}
-        Registry("models").update(models_dict)
 
         return models_dict
 
@@ -213,7 +212,6 @@ class GraphTest(unittest.TestCase):
     @unittest.skipIf(os.name != 'posix', "Skipping because timeout not implemented on non-Unix systems")
     def test_model_timeout(self):
         sleepy_model = PyModuleModel('propnet.core.tests.sleepy_model')
-        # Registry("models")[sleepy_model.name] = sleepy_model
         g = Graph(models={sleepy_model.name: sleepy_model})
         q = QuantityFactory.create_quantity("A", 5, 'dimensionless')
         with Timer('model_timeout'):

--- a/propnet/core/tests/test_graph.py
+++ b/propnet/core/tests/test_graph.py
@@ -213,7 +213,7 @@ class GraphTest(unittest.TestCase):
     @unittest.skipIf(os.name != 'posix', "Skipping because timeout not implemented on non-Unix systems")
     def test_model_timeout(self):
         sleepy_model = PyModuleModel('propnet.core.tests.sleepy_model')
-        Registry("models")[sleepy_model.name] = sleepy_model
+        # Registry("models")[sleepy_model.name] = sleepy_model
         g = Graph(models={sleepy_model.name: sleepy_model})
         q = QuantityFactory.create_quantity("A", 5, 'dimensionless')
         with Timer('model_timeout'):

--- a/propnet/core/tests/test_material.py
+++ b/propnet/core/tests/test_material.py
@@ -5,23 +5,26 @@ from propnet.core.quantity import QuantityFactory
 from propnet.core.graph import Graph
 from propnet.core.provenance import ProvenanceElement
 
-# noinspection PyUnresolvedReferences
-import propnet.symbols
+from propnet.symbols import add_builtin_symbols_to_registry
 from propnet.core.registry import Registry
 
 
 class MaterialTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        add_builtin_symbols_to_registry()
+        # Create some test properties and a few base objects
+        cls.q1 = QuantityFactory.create_quantity(Registry("symbols")['bulk_modulus'],
+                                                 ureg.Quantity.from_tuple([200, [['gigapascals', 1]]]))
+        cls.q2 = QuantityFactory.create_quantity(Registry("symbols")['shear_modulus'],
+                                                 ureg.Quantity.from_tuple([100, [['gigapascals', 1]]]))
+        cls.q3 = QuantityFactory.create_quantity(Registry("symbols")['bulk_modulus'],
+                                                 ureg.Quantity.from_tuple([300, [['gigapascals', 1]]]))
+        cls.material = None
+        cls.graph = Graph()
 
     def setUp(self):
-        # Create some test properties and a few base objects
-        self.q1 = QuantityFactory.create_quantity(Registry("symbols")['bulk_modulus'],
-                                                  ureg.Quantity.from_tuple([200, [['gigapascals', 1]]]))
-        self.q2 = QuantityFactory.create_quantity(Registry("symbols")['shear_modulus'],
-                                                  ureg.Quantity.from_tuple([100, [['gigapascals', 1]]]))
-        self.q3 = QuantityFactory.create_quantity(Registry("symbols")['bulk_modulus'],
-                                                  ureg.Quantity.from_tuple([300, [['gigapascals', 1]]]))
         self.material = Material()
-        self.graph = Graph()
 
     def test_material_setup(self):
         self.assertTrue(len(self.material._symbol_to_quantity) == 0,
@@ -95,7 +98,8 @@ class MaterialTest(unittest.TestCase):
                                                          provenance=ProvenanceElement(model='default')))
         self.assertEqual(list(material['relative_permeability'])[0],
                          QuantityFactory.create_quantity("relative_permeability", 1,
-                         provenance=ProvenanceElement(model='default')))
+                                                         provenance=ProvenanceElement(model='default')))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/propnet/core/tests/test_model.py
+++ b/propnet/core/tests/test_model.py
@@ -45,7 +45,7 @@ class ModelTest(unittest.TestCase):
         A = Symbol('a', ['A'], ['A'], units=[1.0, [['centimeter', 2.0]]], shape=[1])
 
         for sym in (L, A):
-            Registry("symbol")[sym] = sym
+            Registry("symbols")[sym] = sym
             Registry("units")[sym] = sym.units
 
         get_area_config = {
@@ -69,7 +69,7 @@ class ModelTest(unittest.TestCase):
         A = Symbol('a', ['A'], ['A'], units='dimensionless', shape=1)
         B = Symbol('b', ['B'], ['B'], units='dimensionless', shape=1)
         for sym in (B, A):
-            Registry("symbol")[sym] = sym
+            Registry("symbols")[sym] = sym
             Registry("units")[sym] = sym.units
         get_config = {
             'name': 'equality',
@@ -91,7 +91,7 @@ class ModelTest(unittest.TestCase):
         A = Symbol('a', ['A'], ['A'], units='dimensionless', shape=1)
         B = Symbol('b', ['B'], ['B'], units='dimensionless', shape=1)
         for sym in (B, A):
-            Registry("symbol")[sym] = sym
+            Registry("symbols")[sym] = sym
             Registry("units")[sym] = sym.units
         get_config = {
             'name': 'add_complex_value',

--- a/propnet/core/tests/test_model.py
+++ b/propnet/core/tests/test_model.py
@@ -3,11 +3,6 @@ import unittest
 import math
 import numpy as np
 
-# noinspection PyUnresolvedReferences
-import propnet.models
-# noinspection PyUnresolvedReferences
-import propnet.symbols
-
 from propnet.core.models import EquationModel
 from propnet.core.symbols import Symbol
 from propnet.core.quantity import QuantityFactory
@@ -19,8 +14,8 @@ from propnet.core.registry import Registry
 
 
 class ModelTest(unittest.TestCase):
-
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         non_builtin_syms = [k for k, v in Registry("symbols").items() if not v.is_builtin]
         for sym in non_builtin_syms:
             Registry("symbols").pop(sym)

--- a/propnet/core/tests/test_model.py
+++ b/propnet/core/tests/test_model.py
@@ -106,6 +106,41 @@ class ModelTest(unittest.TestCase):
         self.assertTrue(out['successful'])
         self.assertTrue(np.isclose(out['a'].magnitude, 6j))
 
+    def test_model_register_unregister(self):
+        A = Symbol('a', ['A'], ['A'], units='dimensionless', shape=1)
+        B = Symbol('b', ['B'], ['B'], units='dimensionless', shape=1)
+        C = Symbol('c', ['C'], ['C'], units='dimensionless', shape=1)
+        D = Symbol('d', ['D'], ['D'], units='dimensionless', shape=1)
+        m = EquationModel('equation_model_to_remove', ['a = b * 3'], symbol_property_map={'a': A, 'b': B})
+        self.assertIn(m.name, Registry("models"))
+        self.assertTrue(m.registered)
+        m.unregister()
+        self.assertNotIn(m.name, Registry("models"))
+        self.assertFalse(m.registered)
+        m.register()
+        self.assertTrue(m.registered)
+        with self.assertRaises(KeyError):
+            m.register(overwrite_registry=False)
+
+        m.unregister()
+        m = EquationModel('equation_model_to_remove', ['a = b * 3'], symbol_property_map={'a': A, 'b': B},
+                          register=False)
+        self.assertNotIn(m.name, Registry("models"))
+        self.assertFalse(m.registered)
+
+        m.register()
+        with self.assertRaises(KeyError):
+            _ = EquationModel('equation_model_to_remove', ['a = b * 3'],
+                              symbol_property_map={'a': A, 'b': B},
+                              register=True, overwrite_registry=False)
+
+        m_replacement = EquationModel('equation_model_to_remove', ['c = d * 3'],
+                                      symbol_property_map={'c': C, 'd': D})
+
+        m_registered = Registry("models")['equation_model_to_remove']
+        self.assertIs(m_registered, m_replacement)
+        self.assertIsNot(m_registered, m)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/propnet/core/tests/test_quantity.py
+++ b/propnet/core/tests/test_quantity.py
@@ -25,12 +25,20 @@ TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 class QuantityTest(unittest.TestCase):
-    def setUp(self):
-        self.custom_symbol = Symbol("A", units='dimensionless')
-        self.constraint_symbol = Symbol("A", constraint="A > 0",
+    @classmethod
+    def setUpClass(cls):
+        cls.custom_symbol = Symbol("A", units='dimensionless')
+        cls.constraint_symbol = Symbol("A", constraint="A > 0",
                                         units='dimensionless')
-        self.custom_object_symbol = Symbol("B", category='object')
-        self.maxDiff = None
+        cls.custom_object_symbol = Symbol("B", category='object')
+        cls.maxDiff = None
+
+    @classmethod
+    def tearDownClass(cls):
+        non_builtin_syms = [k for k, v in Registry("symbols").items() if not v.is_builtin]
+        for sym in non_builtin_syms:
+            Registry("symbols").pop(sym)
+            Registry("units").pop(sym)
 
     def test_quantity_construction(self):
         # From custom numerical symbol
@@ -959,6 +967,7 @@ class QuantityTest(unittest.TestCase):
         q = QuantityFactory.create_quantity(self.custom_symbol, 1, 'dimensionless', tags='custom')
         self.assertEqual(str(q), "<A, 1 dimensionless, ['custom']>")
         self.assertEqual(repr(q), "<A, 1 dimensionless, ['custom']>")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/propnet/core/tests/test_registry.py
+++ b/propnet/core/tests/test_registry.py
@@ -13,6 +13,14 @@ class RegistryTest(unittest.TestCase):
         self.assertTrue(test_reg is test_reg2)
         self.assertTrue(test_reg is not test_reg3)
 
+    def test_clear_registries(self):
+        Registry("to_clear")['entry'] = 'data'
+        self.assertIn('to_clear', Registry.all_instances.keys())
+        self.assertIn('entry', Registry("to_clear").keys())
+        self.assertEqual(Registry("to_clear")['entry'], 'data')
+        Registry.clear_all_registries()
+        self.assertNotIn('to_clear', Registry.all_instances.keys())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/propnet/core/tests/test_symbol.py
+++ b/propnet/core/tests/test_symbol.py
@@ -5,11 +5,14 @@ from propnet.core.registry import Registry
 
 
 class SymbolTest(unittest.TestCase):
-    def setUp(self):
-        self.old_symbol = Registry("symbols").get("youngs_modulus")
+    @classmethod
+    def setUpClass(cls):
+        cls.old_symbol = Registry("symbols").get("youngs_modulus")
 
-    def tearDown(self):
-        Registry("symbol")['youngs_modulus'] = self.old_symbol
+    @classmethod
+    def tearDownClass(cls):
+        if cls.old_symbol is not None:
+            Registry("symbol")['youngs_modulus'] = cls.old_symbol
 
     def test_property_construction(self):
         sample_symbol_type_dict = {

--- a/propnet/core/tests/test_symbol.py
+++ b/propnet/core/tests/test_symbol.py
@@ -1,9 +1,16 @@
 import unittest
 
 from propnet.core.symbols import Symbol
+from propnet.core.registry import Registry
 
 
 class SymbolTest(unittest.TestCase):
+    def setUp(self):
+        self.old_symbol = Registry("symbols").get("youngs_modulus")
+
+    def tearDown(self):
+        Registry("symbol")['youngs_modulus'] = self.old_symbol
+
     def test_property_construction(self):
         sample_symbol_type_dict = {
             'name': 'youngs_modulus',

--- a/propnet/core/tests/test_symbol.py
+++ b/propnet/core/tests/test_symbol.py
@@ -7,12 +7,11 @@ from propnet.core.registry import Registry
 class SymbolTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.old_symbol = Registry("symbols").get("youngs_modulus")
+        Registry.clear_all_registries()
 
     @classmethod
     def tearDownClass(cls):
-        if cls.old_symbol is not None:
-            Registry("symbol")['youngs_modulus'] = cls.old_symbol
+        Registry.clear_all_registries()
 
     def test_property_construction(self):
         sample_symbol_type_dict = {
@@ -26,7 +25,7 @@ class SymbolTest(unittest.TestCase):
 
         sample_symbol_type = Symbol(
             name='youngs_modulus',  #
-            units=[1.0, [["gigapascal", 1.0]]],  #ureg.parse_expression("GPa"),
+            units=[1.0, [["gigapascal", 1.0]]],
             display_names=["Young's modulus", "Elastic modulus"],
             display_symbols=["E"],
             shape=1,
@@ -34,6 +33,36 @@ class SymbolTest(unittest.TestCase):
 
         self.assertEqual(sample_symbol_type,
                          Symbol.from_dict(sample_symbol_type_dict))
+
+    def test_symbol_register_unregister(self):
+        A = Symbol('a', ['A'], ['A'], units='dimensionless', shape=1)
+
+        self.assertIn(A.name, Registry("symbols"))
+        self.assertTrue(A.registered)
+        A.unregister()
+        self.assertNotIn(A.name, Registry("symbols"))
+        self.assertFalse(A.registered)
+        A.register()
+        self.assertTrue(A.registered)
+        with self.assertRaises(KeyError):
+            A.register(overwrite_registry=False)
+
+        A.unregister()
+        A = Symbol('a', ['A'], ['A'], units='dimensionless', shape=1,
+                   register=False)
+        self.assertNotIn(A.name, Registry("symbols"))
+        self.assertFalse(A.registered)
+
+        A.register()
+        with self.assertRaises(KeyError):
+            _ = Symbol('a', ['A'], ['A'], units='dimensionless', shape=1,
+                       register=True, overwrite_registry=False)
+
+        A_replacement = Symbol('a', ['A^*'], ['A^*'], units='kilogram', shape=1)
+
+        A_registered = Registry("symbols")['a']
+        self.assertIs(A_registered, A_replacement)
+        self.assertIsNot(A_registered, A)
 
 
 if __name__ == "__main__":

--- a/propnet/dbtools/correlation.py
+++ b/propnet/dbtools/correlation.py
@@ -9,7 +9,7 @@ import logging
 import re
 
 # noinspection PyUnresolvedReferences
-import propnet.symbols
+import propnet.models
 from propnet.core.registry import Registry
 
 logger = logging.getLogger(__name__)

--- a/propnet/dbtools/tests/test_builder.py
+++ b/propnet/dbtools/tests/test_builder.py
@@ -6,6 +6,7 @@ from monty.json import jsanitize
 from maggma.stores import MemoryStore
 from maggma.runner import Runner
 
+from propnet.models import add_builtin_models_to_registry
 from propnet.dbtools.mp_builder import PropnetBuilder
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -14,6 +15,7 @@ TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 class BuilderTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        add_builtin_models_to_registry()
         cls.materials = MemoryStore()
         cls.materials.connect()
         materials = loadfn(os.path.join(TEST_DIR, "test_materials.json"))

--- a/propnet/dbtools/tests/test_builder.py
+++ b/propnet/dbtools/tests/test_builder.py
@@ -12,12 +12,16 @@ TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 class BuilderTest(unittest.TestCase):
-    def setUp(self):
-        self.materials = MemoryStore()
-        self.materials.connect()
+    @classmethod
+    def setUpClass(cls):
+        cls.materials = MemoryStore()
+        cls.materials.connect()
         materials = loadfn(os.path.join(TEST_DIR, "test_materials.json"))
         materials = jsanitize(materials, strict=True, allow_bson=True)
-        self.materials.update(materials)
+        cls.materials.update(materials)
+        cls.propstore = None
+
+    def setUp(self):
         self.propstore = MemoryStore()
         self.propstore.connect()
 
@@ -65,8 +69,6 @@ class BuilderTest(unittest.TestCase):
                                  date_value)
                 at_deepest_level = True
 
-
-
     # @unittest.skipIf(not os.path.isfile("runner.json"), "No runner file")
     # def test_runner_pipeline(self):
     #     from monty.serialization import loadfn
@@ -89,6 +91,7 @@ class BuilderTest(unittest.TestCase):
                                                "e_above_hull": 0})
         builder.connect()
         dumpfn(list(builder.get_items()), "test_materials.json")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/propnet/dbtools/tests/test_correlation.py
+++ b/propnet/dbtools/tests/test_correlation.py
@@ -9,6 +9,7 @@ from maggma.runner import Runner
 
 from itertools import product
 
+from propnet.models import add_builtin_models_to_registry
 from propnet.dbtools.correlation import CorrelationBuilder
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -17,6 +18,7 @@ TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 class CorrelationTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        add_builtin_models_to_registry()
         cls.propnet_props = ["band_gap_pbe", "bulk_modulus", "vickers_hardness"]
         cls.mp_query_props = ["magnetism.total_magnetization_normalized_vol"]
         cls.mp_props = ["total_magnetization_normalized_vol"]

--- a/propnet/dbtools/tests/test_correlation.py
+++ b/propnet/dbtools/tests/test_correlation.py
@@ -15,29 +15,28 @@ TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 class CorrelationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.propnet_props = ["band_gap_pbe", "bulk_modulus", "vickers_hardness"]
+        cls.mp_query_props = ["magnetism.total_magnetization_normalized_vol"]
+        cls.mp_props = ["total_magnetization_normalized_vol"]
 
-    def setUp(self):
-        self.propnet_props = ["band_gap_pbe", "bulk_modulus", "vickers_hardness"]
-        self.mp_query_props = ["magnetism.total_magnetization_normalized_vol"]
-        self.mp_props = ["total_magnetization_normalized_vol"]
-
-        self.propstore = MemoryStore()
-        self.propstore.connect()
+        cls.propstore = MemoryStore()
+        cls.propstore.connect()
         with open(os.path.join(TEST_DIR, "correlation_propnet_data.json"), 'r') as f:
             materials = json.load(f)
         materials = jsanitize(materials, strict=True, allow_bson=True)
-        self.propstore.update(materials)
-        self.materials = MemoryStore()
-        self.materials.connect()
+        cls.propstore.update(materials)
+        cls.materials = MemoryStore()
+        cls.materials.connect()
         with open(os.path.join(TEST_DIR, "correlation_mp_data.json"), 'r') as f:
             materials = json.load(f)
         materials = jsanitize(materials, strict=True, allow_bson=True)
-        self.materials.update(materials)
-        self.correlation = MemoryStore()
-        self.correlation.connect()
+        cls.materials.update(materials)
+        cls.correlation = None
 
         # vickers hardness (x-axis) vs. bulk modulus (y-axis)
-        self.correlation_values_vickers_bulk = {
+        cls.correlation_values_vickers_bulk = {
             'linlsq': 0.07030669243379202,
             'pearson': 0.2651540918669593,
             'spearman': 0.6759408985224631,
@@ -45,7 +44,7 @@ class CorrelationTest(unittest.TestCase):
             'theilsen': -3.9351770244782456,
             'ransac': -4.528702228127463}
 
-        self.correlation_values_bulk_vickers = {
+        cls.correlation_values_bulk_vickers = {
             'linlsq': 0.07030669243379202,
             'pearson': 0.2651540918669593,
             'spearman': 0.6759408985224631,
@@ -53,9 +52,14 @@ class CorrelationTest(unittest.TestCase):
             'theilsen': 0.040612225849504746,
             'ransac': 0.04576997520687298}
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         if os.path.exists(os.path.join(TEST_DIR, "test_output.json")):
             os.remove(os.path.join(TEST_DIR, "test_output.json"))
+
+    def setUp(self):
+        self.correlation = MemoryStore()
+        self.correlation.connect()
 
     def test_serial_runner(self):
         builder = CorrelationBuilder(self.propstore, self.materials, self.correlation)

--- a/propnet/ext/tests/test_matproj.py
+++ b/propnet/ext/tests/test_matproj.py
@@ -5,22 +5,22 @@ from propnet.ext.matproj import MPRester
 
 from propnet.models import add_builtin_models_to_registry
 
-add_builtin_models_to_registry()
 
 mpr = MPRester()
 
 
 @unittest.skipIf(mpr.api_key == "", "No API key provided. Skipping MPRester tests.")
 class MPResterTest(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
+        add_builtin_models_to_registry()
+        cls.mpr = mpr
         mpid = 'mp-1153'
-        self.mpr = MPRester()
-        self.mat = self.mpr.get_material_for_mpid(mpid)
+        cls.mat = cls.mpr.get_material_for_mpid(mpid)
 
     def test_load_properties(self):
         mpid = 'mp-1153'
-        mpr = MPRester()
-        mat = mpr.get_material_for_mpid(mpid)
+        mat = self.mpr.get_material_for_mpid(mpid)
         quantity = next(iter(mat['structure']))
         self.assertEqual(quantity.provenance.source['source'], "Materials Project")
         self.assertIn('structure', mat.get_symbols())

--- a/propnet/ext/tests/test_matproj.py
+++ b/propnet/ext/tests/test_matproj.py
@@ -3,6 +3,10 @@ import unittest
 from propnet.core.graph import Graph
 from propnet.ext.matproj import MPRester
 
+from propnet.models import add_builtin_models_to_registry
+
+add_builtin_models_to_registry()
+
 mpr = MPRester()
 
 

--- a/propnet/models/__init__.py
+++ b/propnet/models/__init__.py
@@ -8,7 +8,10 @@ for name, model in Registry("models").items():
     globals()[name] = model
 
 
-def add_builtin_models_to_registry():
-    serialized.add_builtin_models_to_registry()
-    python.add_builtin_models_to_registry()
-    composite.add_builtin_models_to_registry()
+def add_builtin_models_to_registry(readd_symbols=True):
+    if readd_symbols:
+        from propnet.symbols import add_builtin_symbols_to_registry
+        add_builtin_symbols_to_registry()
+    serialized.add_builtin_models_to_registry(readd_symbols=False)
+    python.add_builtin_models_to_registry(readd_symbols=False)
+    composite.add_builtin_models_to_registry(readd_symbols=False)

--- a/propnet/models/__init__.py
+++ b/propnet/models/__init__.py
@@ -3,15 +3,21 @@ import propnet.symbols
 from propnet.models import serialized, python, composite
 from propnet.core.registry import Registry
 
+
 # This is just to enable importing the model directly from this module for example code generation
-for name, model in Registry("models").items():
-    globals()[name] = model
+def _update_globals():
+    for name, model in Registry("models").items():
+        if model.is_builtin:
+            globals()[name] = model
 
 
-def add_builtin_models_to_registry(readd_symbols=True):
-    if readd_symbols:
-        from propnet.symbols import add_builtin_symbols_to_registry
-        add_builtin_symbols_to_registry()
-    serialized.add_builtin_models_to_registry(readd_symbols=False)
-    python.add_builtin_models_to_registry(readd_symbols=False)
-    composite.add_builtin_models_to_registry(readd_symbols=False)
+def add_builtin_models_to_registry(register_symbols=True):
+    if register_symbols:
+        propnet.symbols.add_builtin_symbols_to_registry()
+    serialized.add_builtin_models_to_registry(register_symbols=False)
+    python.add_builtin_models_to_registry(register_symbols=False)
+    composite.add_builtin_models_to_registry(register_symbols=False)
+    _update_globals()
+
+
+_update_globals()

--- a/propnet/models/__init__.py
+++ b/propnet/models/__init__.py
@@ -1,3 +1,5 @@
+# noinspection PyUnresolvedReferences
+import propnet.symbols
 from propnet.models import serialized, python, composite
 from propnet.core.registry import Registry
 

--- a/propnet/models/composite/__init__.py
+++ b/propnet/models/composite/__init__.py
@@ -1,15 +1,10 @@
 from pkgutil import iter_modules
 from propnet.core.models import PyModuleCompositeModel
-from propnet.core.registry import Registry
-# from propnet.models import python
-
-COMPOSITE_MODEL_DICT = Registry("composite_models")
-
-# Load composite models
-COMPOSITE_MODULE_LIST = iter_modules(__path__)
 
 
 def add_builtin_models_to_registry(readd_symbols=True):
+    # Load composite models
+    COMPOSITE_MODULE_LIST = iter_modules(__path__)
     if readd_symbols:
         from propnet.symbols import add_builtin_symbols_to_registry
         add_builtin_symbols_to_registry()

--- a/propnet/models/composite/__init__.py
+++ b/propnet/models/composite/__init__.py
@@ -9,10 +9,13 @@ COMPOSITE_MODEL_DICT = Registry("composite_models")
 COMPOSITE_MODULE_LIST = iter_modules(__path__)
 
 
-def add_builtin_models_to_registry():
+def add_builtin_models_to_registry(readd_symbols=True):
+    if readd_symbols:
+        from propnet.symbols import add_builtin_symbols_to_registry
+        add_builtin_symbols_to_registry()
     for _, module_name, _ in COMPOSITE_MODULE_LIST:
         module_path = "propnet.models.composite.{}".format(module_name)
-        PyModuleCompositeModel(module_path, is_builtin=True)
+        PyModuleCompositeModel(module_path, is_builtin=True, overwrite_registry=True)
 
 
 add_builtin_models_to_registry()

--- a/propnet/models/composite/__init__.py
+++ b/propnet/models/composite/__init__.py
@@ -12,8 +12,7 @@ COMPOSITE_MODULE_LIST = iter_modules(__path__)
 def add_builtin_models_to_registry():
     for _, module_name, _ in COMPOSITE_MODULE_LIST:
         module_path = "propnet.models.composite.{}".format(module_name)
-        model = PyModuleCompositeModel(module_path, is_builtin=True)
-        COMPOSITE_MODEL_DICT.update({model.name: model})
+        PyModuleCompositeModel(module_path, is_builtin=True)
 
 
 add_builtin_models_to_registry()

--- a/propnet/models/composite/__init__.py
+++ b/propnet/models/composite/__init__.py
@@ -1,16 +1,22 @@
 from pkgutil import iter_modules
 from propnet.core.models import PyModuleCompositeModel
 
+# This list is to test if we have models with the same name
+_COMPOSITE_MODEL_NAMES_LIST = []
 
-def add_builtin_models_to_registry(readd_symbols=True):
+
+def add_builtin_models_to_registry(register_symbols=True):
+    _COMPOSITE_MODEL_NAMES_LIST.clear()
     # Load composite models
-    COMPOSITE_MODULE_LIST = iter_modules(__path__)
-    if readd_symbols:
+    composite_module_list = iter_modules(__path__)
+    if register_symbols:
         from propnet.symbols import add_builtin_symbols_to_registry
         add_builtin_symbols_to_registry()
-    for _, module_name, _ in COMPOSITE_MODULE_LIST:
+    for _, module_name, _ in composite_module_list:
         module_path = "propnet.models.composite.{}".format(module_name)
-        PyModuleCompositeModel(module_path, is_builtin=True, overwrite_registry=True)
+        model = PyModuleCompositeModel(module_path, is_builtin=True, overwrite_registry=True)
+        globals()[model.name] = model
+        _COMPOSITE_MODEL_NAMES_LIST.append(model.name)
 
 
 add_builtin_models_to_registry()

--- a/propnet/models/python/__init__.py
+++ b/propnet/models/python/__init__.py
@@ -12,8 +12,7 @@ MODULE_LIST = iter_modules(__path__)
 def add_builtin_models_to_registry():
     for _, module_name, _ in MODULE_LIST:
         module_path = "propnet.models.python.{}".format(module_name)
-        model = PyModuleModel(module_path, is_builtin=True)
-        Registry("models").update({model.name: model})
+        PyModuleModel(module_path, is_builtin=True)
 
 
 add_builtin_models_to_registry()

--- a/propnet/models/python/__init__.py
+++ b/propnet/models/python/__init__.py
@@ -9,10 +9,13 @@ DEFAULT_MODEL_DICT = Registry("models")
 MODULE_LIST = iter_modules(__path__)
 
 
-def add_builtin_models_to_registry():
+def add_builtin_models_to_registry(readd_symbols=True):
+    if readd_symbols:
+        from propnet.symbols import add_builtin_symbols_to_registry
+        add_builtin_symbols_to_registry()
     for _, module_name, _ in MODULE_LIST:
         module_path = "propnet.models.python.{}".format(module_name)
-        PyModuleModel(module_path, is_builtin=True)
+        PyModuleModel(module_path, is_builtin=True, overwrite_registry=True)
 
 
 add_builtin_models_to_registry()

--- a/propnet/models/python/__init__.py
+++ b/propnet/models/python/__init__.py
@@ -1,15 +1,10 @@
 from pkgutil import iter_modules
 from propnet.core.models import PyModuleModel
-from propnet.core.registry import Registry
-
-
-DEFAULT_MODEL_DICT = Registry("models")
-
-# Load python models
-MODULE_LIST = iter_modules(__path__)
 
 
 def add_builtin_models_to_registry(readd_symbols=True):
+    # Load python models
+    MODULE_LIST = iter_modules(__path__)
     if readd_symbols:
         from propnet.symbols import add_builtin_symbols_to_registry
         add_builtin_symbols_to_registry()

--- a/propnet/models/python/__init__.py
+++ b/propnet/models/python/__init__.py
@@ -1,16 +1,22 @@
 from pkgutil import iter_modules
 from propnet.core.models import PyModuleModel
 
+# This list is to test if we have models with the same name
+_PYTHON_MODEL_NAMES_LIST = []
 
-def add_builtin_models_to_registry(readd_symbols=True):
+
+def add_builtin_models_to_registry(register_symbols=True):
+    _PYTHON_MODEL_NAMES_LIST.clear()
     # Load python models
-    MODULE_LIST = iter_modules(__path__)
-    if readd_symbols:
+    python_module_list = iter_modules(__path__)
+    if register_symbols:
         from propnet.symbols import add_builtin_symbols_to_registry
         add_builtin_symbols_to_registry()
-    for _, module_name, _ in MODULE_LIST:
+    for _, module_name, _ in python_module_list:
         module_path = "propnet.models.python.{}".format(module_name)
-        PyModuleModel(module_path, is_builtin=True, overwrite_registry=True)
+        model = PyModuleModel(module_path, is_builtin=True, overwrite_registry=True)
+        globals()[model.name] = model
+        _PYTHON_MODEL_NAMES_LIST.append(model.name)
 
 
 add_builtin_models_to_registry()

--- a/propnet/models/serialized/__init__.py
+++ b/propnet/models/serialized/__init__.py
@@ -10,12 +10,13 @@ EQUATION_MODEL_DIR = os.path.join(os.path.dirname(__file__))
 EQUATION_MODULE_FILES = glob(EQUATION_MODEL_DIR + '/*.yaml')
 
 
-def add_builtin_models_to_registry():
-    # noinspection PyUnresolvedReferences
-    import propnet.symbols
+def add_builtin_models_to_registry(readd_symbols=True):
+    if readd_symbols:
+        from propnet.symbols import add_builtin_symbols_to_registry
+        add_builtin_symbols_to_registry()
     for filename in EQUATION_MODULE_FILES:
         model_path = os.path.join(EQUATION_MODEL_DIR, filename)
-        EquationModel.from_file(model_path, is_builtin=True)
+        EquationModel.from_file(model_path, is_builtin=True, overwrite_registry=True)
 
 
 add_builtin_models_to_registry()

--- a/propnet/models/serialized/__init__.py
+++ b/propnet/models/serialized/__init__.py
@@ -1,22 +1,25 @@
 import os
 from propnet.core.models import EquationModel
-from propnet.core.registry import Registry
 from glob import glob
 
-DEFAULT_MODEL_DICT = Registry("models")
-
-# Load equation models
-EQUATION_MODEL_DIR = os.path.join(os.path.dirname(__file__))
-EQUATION_MODULE_FILES = glob(EQUATION_MODEL_DIR + '/*.yaml')
+# This list is to test if we have models with the same name
+_EQUATION_MODEL_NAMES_LIST = []
 
 
-def add_builtin_models_to_registry(readd_symbols=True):
-    if readd_symbols:
+def add_builtin_models_to_registry(register_symbols=True):
+    _EQUATION_MODEL_NAMES_LIST.clear()
+    # Load equation models
+    equation_model_dir = os.path.join(os.path.dirname(__file__))
+    equation_module_files = glob(equation_model_dir + '/*.yaml')
+
+    if register_symbols:
         from propnet.symbols import add_builtin_symbols_to_registry
         add_builtin_symbols_to_registry()
-    for filename in EQUATION_MODULE_FILES:
-        model_path = os.path.join(EQUATION_MODEL_DIR, filename)
-        EquationModel.from_file(model_path, is_builtin=True, overwrite_registry=True)
+    for filename in equation_module_files:
+        model_path = os.path.join(equation_model_dir, filename)
+        model = EquationModel.from_file(model_path, is_builtin=True, overwrite_registry=True)
+        globals()[model.name] = model
+        _EQUATION_MODEL_NAMES_LIST.append(model.name)
 
 
 add_builtin_models_to_registry()

--- a/propnet/models/serialized/__init__.py
+++ b/propnet/models/serialized/__init__.py
@@ -11,10 +11,11 @@ EQUATION_MODULE_FILES = glob(EQUATION_MODEL_DIR + '/*.yaml')
 
 
 def add_builtin_models_to_registry():
+    # noinspection PyUnresolvedReferences
+    import propnet.symbols
     for filename in EQUATION_MODULE_FILES:
         model_path = os.path.join(EQUATION_MODEL_DIR, filename)
-        model = EquationModel.from_file(model_path, is_builtin=True)
-        Registry("models").update({model.name: model})
+        EquationModel.from_file(model_path, is_builtin=True)
 
 
 add_builtin_models_to_registry()

--- a/propnet/models/tests/test_default_models.py
+++ b/propnet/models/tests/test_default_models.py
@@ -4,11 +4,13 @@ import unittest
 from propnet.models import add_builtin_models_to_registry
 from propnet.core.registry import Registry
 
-Registry("models").clear()
-add_builtin_models_to_registry()
-
 
 class DefaultModelsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        Registry.clear_all_registries()
+        add_builtin_models_to_registry()
+
     def test_instantiate_all_models(self):
         models_to_test = []
         for model_name in Registry("models").keys():

--- a/propnet/models/tests/test_default_models.py
+++ b/propnet/models/tests/test_default_models.py
@@ -11,6 +11,29 @@ class DefaultModelsTest(unittest.TestCase):
         Registry.clear_all_registries()
         add_builtin_models_to_registry()
 
+    def test_reimport_models(self):
+        Registry("models").pop('debye_temperature')
+        Registry("models").pop('is_metallic')
+        Registry("composite_models").pop('pilling_bedworth_ratio')
+        self.assertNotIn("debye_temperature", Registry("models"))
+        self.assertNotIn("is_metallic", Registry("models"))
+        self.assertNotIn("pilling_bedworth_ratio", Registry("composite_models"))
+        from propnet.models.serialized import add_builtin_models_to_registry as serialized_add
+        serialized_add()
+        self.assertIn("debye_temperature", Registry("models"))
+        self.assertNotIn("is_metallic", Registry("models"))
+        self.assertNotIn("pilling_bedworth_ratio", Registry("composite_models"))
+        from propnet.models.python import add_builtin_models_to_registry as python_add
+        python_add()
+        self.assertIn("debye_temperature", Registry("models"))
+        self.assertIn("is_metallic", Registry("models"))
+        self.assertNotIn("pilling_bedworth_ratio", Registry("composite_models"))
+        from propnet.models.composite import add_builtin_models_to_registry as composite_add
+        composite_add()
+        self.assertIn("debye_temperature", Registry("models"))
+        self.assertIn("is_metallic", Registry("models"))
+        self.assertIn("pilling_bedworth_ratio", Registry("composite_models"))
+
     def test_instantiate_all_models(self):
         models_to_test = []
         for model_name in Registry("models").keys():

--- a/propnet/models/tests/test_default_models.py
+++ b/propnet/models/tests/test_default_models.py
@@ -1,8 +1,11 @@
 import unittest
 
 # noinspection PyUnresolvedReferences
-import propnet.models
+from propnet.models import add_builtin_models_to_registry
 from propnet.core.registry import Registry
+
+Registry("models").clear()
+add_builtin_models_to_registry()
 
 
 class DefaultModelsTest(unittest.TestCase):

--- a/propnet/symbols/__init__.py
+++ b/propnet/symbols/__init__.py
@@ -22,16 +22,8 @@ def _update_registry():
         d = loadfn(f)
         d['is_builtin'] = True
         symbol_type = Symbol.from_dict(d)
-        Registry("symbols")[symbol_type.name] = symbol_type
-        if symbol_type.default_value is not None:
-            Registry("symbol_values")[symbol_type] = symbol_type.default_value
         if "{}.yaml".format(symbol_type.name) not in f:
             raise ValueError('Name/filename mismatch in {}'.format(f))
-
-    # Stores all loaded properties' names in a tuple in the global scope.
-    Registry("units").update(
-        {name: symbol.units.format_babel() if symbol.units else None
-         for name, symbol in Registry("symbols").items()})
 
 
 def _update_symbol_type_names():

--- a/propnet/symbols/__init__.py
+++ b/propnet/symbols/__init__.py
@@ -17,7 +17,7 @@ _DEFAULT_SYMBOL_TYPE_FILES = glob(
 DEFAULT_SYMBOL_TYPE_NAMES = None
 
 
-def _update_registry():
+def add_builtin_symbols_to_registry():
     for f in _DEFAULT_SYMBOL_TYPE_FILES:
         d = loadfn(f)
         d['is_builtin'] = True
@@ -26,19 +26,10 @@ def _update_registry():
         if "{}.yaml".format(symbol_type.name) not in f:
             raise ValueError('Name/filename mismatch in {}'.format(f))
 
-
-def _update_symbol_type_names():
-    # TODO: Can we remove this?
-    globals()['DEFAULT_SYMBOL_TYPE_NAMES'] = tuple(Registry("symbols").keys())
-
-
-def add_builtin_symbols_to_registry():
-    _update_registry()
-    _update_symbol_type_names()
+    # This is just to enable importing this module
+    for name, symbol in Registry("symbols").items():
+        if symbol.is_builtin:
+            globals()[name] = symbol
 
 
 add_builtin_symbols_to_registry()
-
-# This is just to enable importing this module
-for name, symbol in Registry("symbols").items():
-    globals()[name] = symbol

--- a/propnet/symbols/__init__.py
+++ b/propnet/symbols/__init__.py
@@ -21,6 +21,7 @@ def _update_registry():
     for f in _DEFAULT_SYMBOL_TYPE_FILES:
         d = loadfn(f)
         d['is_builtin'] = True
+        d['overwrite_registry'] = True
         symbol_type = Symbol.from_dict(d)
         if "{}.yaml".format(symbol_type.name) not in f:
             raise ValueError('Name/filename mismatch in {}'.format(f))

--- a/propnet/symbols/tests/test_default_symbols.py
+++ b/propnet/symbols/tests/test_default_symbols.py
@@ -1,18 +1,20 @@
 import unittest
 
-# noinspection PyUnresolvedReferences
-import propnet.symbols
+from propnet.symbols import add_builtin_symbols_to_registry
 from propnet.core.registry import Registry
 
 
 class SymbolsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        Registry.clear_all_registries()
+        add_builtin_symbols_to_registry()
+
     def test_property_formatting(self):
         """
         Goes through the Quantity .yaml files and ensures the definitions are complete.
         """
         for st in Registry("symbols").values():
-            if not st.is_builtin:
-                continue
             self.assertTrue(st.name is not None and st.name.isidentifier())
             self.assertTrue(
                 st.category is not None

--- a/propnet/symbols/tests/test_default_symbols.py
+++ b/propnet/symbols/tests/test_default_symbols.py
@@ -10,6 +10,12 @@ class SymbolsTest(unittest.TestCase):
         Registry.clear_all_registries()
         add_builtin_symbols_to_registry()
 
+    def test_reimport_symbols(self):
+        Registry("symbols").pop('youngs_modulus')
+        self.assertNotIn('youngs_modulus', Registry("symbols"))
+        add_builtin_symbols_to_registry()
+        self.assertIn('youngs_modulus', Registry("symbols"))
+
     def test_property_formatting(self):
         """
         Goes through the Quantity .yaml files and ensures the definitions are complete.

--- a/propnet/web/tests/test_web.py
+++ b/propnet/web/tests/test_web.py
@@ -2,6 +2,7 @@ import unittest
 import json
 
 from propnet.core.graph import Graph
+from propnet.symbols import add_builtin_symbols_to_registry
 import os
 
 no_store_file = os.environ.get('PROPNET_STORE_FILE') is None
@@ -12,6 +13,8 @@ if not no_store_file:
 routes = [
     '/'
 ]
+
+add_builtin_symbols_to_registry()
 
 
 @unittest.skipIf(no_store_file,

--- a/propnet/web/tests/test_web.py
+++ b/propnet/web/tests/test_web.py
@@ -2,7 +2,7 @@ import unittest
 import json
 
 from propnet.core.graph import Graph
-from propnet.symbols import add_builtin_symbols_to_registry
+from propnet.models import add_builtin_models_to_registry
 import os
 
 no_store_file = os.environ.get('PROPNET_STORE_FILE') is None
@@ -14,8 +14,6 @@ routes = [
     '/'
 ]
 
-add_builtin_symbols_to_registry()
-
 
 @unittest.skipIf(no_store_file,
                  "No data store provided. Skipping web tests.")
@@ -23,6 +21,10 @@ class WebTest(unittest.TestCase):
     """
     Base class for dash unittests
     """
+    @classmethod
+    def setUpClass(cls):
+        add_builtin_models_to_registry()
+
     def setUp(self):
         self.app = app
         self.client = self.app.server.test_client()

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ scipy>=1.0.1
 sympy>=1.3
 gbml>=1.1.0
 minepy>=1.2.3
+sphinx>=1.8.5
 sphinx-rtd-theme>=0.4.3
 sphinxcontrib-apidoc>=0.3.0
 -e .


### PR DESCRIPTION
Up until now, the core of propnet has assumed that the user would be using the built-in models and symbols. In turn, the code imports all of the models and symbols. However, with the new registry for models and symbols, we don't want to assume that. We want the user to explicitly import the built-ins if they want them.

Changes made with this PR:
- Remove code from core library which imports the built-ins automatically or assumes use of the built-ins
- Ensure other code, like `dbtools` and tests import built-ins as needed.
- Register models/symbols upon instantiation with keyword arg `register` to control auto-registration and `overwrite_registry` to force registration if a model/symbol by the same name already exists in the registry.
- Add helper member functions to register/unregister symbols and models.
- Add test for doc building because changes made to the code broke the sphinx doc builder.
- Fix tests that break because of changed functionality.

The last point regarding tests was a bit of an unforeseen hurdle. When running tests, each test module is loaded into the same global namespace. So, if one test module imports the built-in models/symbols, or the test methods generate new, non-built-ins that get registered, these will persist in the registry for subsequent tests and testing modules. It is possible to run `nose` with the `--with-isolation` flag, which clears the global namespace between each test module, but this causes problems with `--with-coverage`, which we need for Travis. So, test classes were adapted to force re-registry of models/symbols where the test class needed the built-ins. If a test class created non-built-in symbols, they were removed from the registry upon completion of that test module.

The above adaptations also allowed for much set-up and tear-down code to be moved from `setUp()` and `tearDown()` to `setUpClass()` and `tearDownClass()`, respectively. This keeps code from being re-run during each test that didn't need to be run.