### PR TITLE
Create RTD config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.6.8
+  version: 3.6
   install:
     - requirements: requirements.txt
     - requirements: requirements-optional.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,21 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: []
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.6.8
+  install:
+    - requirements: requirements.txt
+    - requirements: requirements-optional.txt
+  system_packages: true


### PR DESCRIPTION
Because we moved some requirements to requirements-optional.txt, we need a config file to ensure our docs build correctly.