### PR TITLE
Change untraversed nodes to gray

### DIFF
--- a/propnet/web/graph_stylesheet.yaml
+++ b/propnet/web/graph_stylesheet.yaml
@@ -34,7 +34,7 @@
     border-style: solid
 - selector: .untraversed
   style:
-    background-color: "#000000"
+    background-color: "#BDBDBD"
 - selector: .unattached
   style:
     background-color: "#FF7777"


### PR DESCRIPTION
I changed it from black to gray. Currently no nodes use this style class, but it is the default in case something doesn't fit. It should have been gray in the first place.