### PR TITLE
Catch errors in correlation calculation

### DIFF
--- a/propnet/dbtools/correlation.py
+++ b/propnet/dbtools/correlation.py
@@ -223,14 +223,14 @@ class CorrelationBuilder(Builder):
             path_length = path_length_xy or path_length_yx
 
         if n_points < 2:
-            correlation = 0.0
+            result = 0.0
         else:
             try:
-                correlation = func(data_x, data_y)
+                result = func(data_x, data_y)
             except Exception as ex:
                 # If correlation fails, catch the error, save it, and move on
-                correlation = ex
-        return prop_x, prop_y, correlation, func_name, n_points, path_length
+                result = ex
+        return prop_x, prop_y, result, func_name, n_points, path_length
 
     @staticmethod
     def _cfunc_mic(x, y):
@@ -343,19 +343,19 @@ class CorrelationBuilder(Builder):
         """
         data = []
         for item in items:
-            prop_x, prop_y, correlation, func_name, n_points, path_length = item
+            prop_x, prop_y, result, func_name, n_points, path_length = item
             d = {'property_x': prop_x,
                  'property_y': prop_y,
                  'correlation_func': func_name,
                  'n_points': n_points,
                  'shortest_path_length': path_length,
                  'id': hash((prop_x, prop_y)) ^ hash(func_name)}
-            if not isinstance(correlation, Exception):
-                d['correlation'] = correlation
+            if not isinstance(result, Exception):
+                d['correlation'] = result
             else:
                 d['correlation'] = None
-                d['error'] = (correlation.__class__.__name__,
-                              correlation.args)
+                d['error'] = (result.__class__.__name__,
+                              result.args)
             data.append(d)
         self.correlation_store.update(data, key='id')
 

--- a/propnet/dbtools/correlation.py
+++ b/propnet/dbtools/correlation.py
@@ -82,6 +82,8 @@ class CorrelationBuilder(Builder):
 
         self._props = props or self.PROPNET_PROPS
 
+        self.total = len(self._props)**2 * len(self._funcs)
+
         super(CorrelationBuilder, self).__init__(sources=[propnet_store],
                                                  targets=[correlation_store],
                                                  **kwargs)
@@ -101,6 +103,8 @@ class CorrelationBuilder(Builder):
              }
 
         """
+        # Update total in case we changed something between instantiation and running
+        self.total = len(self._props)**2 * len(self._funcs)
 
         # combinations_with_replacement() produces all possible pairs of properties
         # without repeating, i.e. will give AB but not BA. Code below manually

--- a/propnet/dbtools/correlation.py
+++ b/propnet/dbtools/correlation.py
@@ -86,7 +86,7 @@ class CorrelationBuilder(Builder):
             raise ValueError("No valid correlation functions selected")
 
         self._props = props or self.PROPNET_PROPS
-        if sample_size < 2:
+        if sample_size is not None and sample_size < 2:
             raise ValueError("Sample size must be greater than 1")
         self.sample_size = sample_size
         self.total = len(self._props)**2 * len(self._funcs)

--- a/propnet/dbtools/correlation.py
+++ b/propnet/dbtools/correlation.py
@@ -368,6 +368,12 @@ class CorrelationBuilder(Builder):
             cursor: (Mongo Store cursor) optional, cursor to close if not automatically closed.
 
         """
+
+        props_to_index = ['property_x', 'property_y', 'correlation_func']
+        for prop in props_to_index:
+            if not self.correlation_store.ensure_index(prop):
+                logger.warning("Could not add index for property {}".format(prop))
+
         if self.out_file:
             try:
                 self.write_correlation_data_file(self.out_file)

--- a/propnet/dbtools/tests/test_correlation.py
+++ b/propnet/dbtools/tests/test_correlation.py
@@ -203,6 +203,9 @@ class CorrelationTest(unittest.TestCase):
             # Because sample size > total docs, should just be total docs
             self.assertEqual(d['n_points'], 200)
 
+        with self.assertRaises(ValueError):
+            _ = CorrelationBuilder(self.propstore, self.correlation, sample_size=1)
+
     # Just here for reference, in case anyone wants to create a new set
     # of test materials. Requires mongogrant read access to knowhere.lbl.gov.
     @unittest.skipIf(True, "Skipping test materials creation")

--- a/propnet/dbtools/tests/test_correlation.py
+++ b/propnet/dbtools/tests/test_correlation.py
@@ -178,6 +178,31 @@ class CorrelationTest(unittest.TestCase):
                 self.assertAlmostEqual(actual_file_data['correlation'][f][iax][iay],
                                        expected_file_data['correlation'][f][iex][iey])
 
+    def test_sample_size_limit(self):
+        # Test sample_size < total docs
+        builder = CorrelationBuilder(self.propstore, self.correlation,
+                                     props=['bulk_modulus', 'vickers_hardness'],
+                                     funcs='linlsq', sample_size=50)
+        runner = Runner([builder])
+        runner.run()
+
+        data = list(self.correlation.query(criteria={}))
+        for d in data:
+            self.assertEqual(d['n_points'], 50)
+
+        # Test sample_size > total docs
+        self.correlation = MemoryStore()
+        builder = CorrelationBuilder(self.propstore, self.correlation,
+                                     props=['bulk_modulus', 'vickers_hardness'],
+                                     funcs='linlsq', sample_size=300)
+        runner = Runner([builder])
+        runner.run()
+
+        data = list(self.correlation.query(criteria={}))
+        for d in data:
+            # Because sample size > total docs, should just be total docs
+            self.assertEqual(d['n_points'], 200)
+
     # Just here for reference, in case anyone wants to create a new set
     # of test materials. Requires mongogrant read access to knowhere.lbl.gov.
     @unittest.skipIf(True, "Skipping test materials creation")

--- a/propnet/dbtools/tests/test_correlation.py
+++ b/propnet/dbtools/tests/test_correlation.py
@@ -179,29 +179,20 @@ class CorrelationTest(unittest.TestCase):
                                        expected_file_data['correlation'][f][iex][iey])
 
     def test_sample_size_limit(self):
-        # Test sample_size < total docs
-        builder = CorrelationBuilder(self.propstore, self.correlation,
-                                     props=['bulk_modulus', 'vickers_hardness'],
-                                     funcs='linlsq', sample_size=50)
-        runner = Runner([builder])
-        runner.run()
+        sample_sizes = [50, 300]
+        expected_n_points = [50, 200]
 
-        data = list(self.correlation.query(criteria={}))
-        for d in data:
-            self.assertEqual(d['n_points'], 50)
+        for sample_size, n_points in zip(sample_sizes, expected_n_points):
+            correlation_store = MemoryStore()
+            builder = CorrelationBuilder(self.propstore, correlation_store,
+                                         props=['bulk_modulus', 'vickers_hardness'],
+                                         funcs='linlsq', sample_size=sample_size)
+            runner = Runner([builder])
+            runner.run()
 
-        # Test sample_size > total docs
-        self.correlation = MemoryStore()
-        builder = CorrelationBuilder(self.propstore, self.correlation,
-                                     props=['bulk_modulus', 'vickers_hardness'],
-                                     funcs='linlsq', sample_size=300)
-        runner = Runner([builder])
-        runner.run()
-
-        data = list(self.correlation.query(criteria={}))
-        for d in data:
-            # Because sample size > total docs, should just be total docs
-            self.assertEqual(d['n_points'], 200)
+            data = list(correlation_store.query(criteria={}))
+            for d in data:
+                self.assertEqual(d['n_points'], n_points)
 
         with self.assertRaises(ValueError):
             _ = CorrelationBuilder(self.propstore, self.correlation, sample_size=1)


### PR DESCRIPTION
The correlation builder didn't gracefully catch errors when the correlation func was run. Now it does and saves it in the db for later review.