### PR TITLE
Remove urllib3 from requirements, update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ install:
   - pip install coverage
   - pip install python-coveralls
 script:
-  - nosetests ./ docs/ --with-coverage --cover-package=propnet
+  - nosetests -v ./ docs/ --with-coverage --cover-package=propnet
 after_success:
   - coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,6 @@ maggma>=0.13.0
 aflow>=0.0.10
 six>=1.12.0
 requests>=2.21.0
-urllib3>=1.24.1
 
 # analysis
 minepy>=1.2.3


### PR DESCRIPTION
It will get installed with `requests` anyway. And this messes with website deployment because of a compatibility issue with the version of urllib3 that was being requested.

Also make nosetests verbose so we can see which test is running.