### PR TITLE
Fix alignment in safari

### DIFF
--- a/propnet/web/layout_refs.py
+++ b/propnet/web/layout_refs.py
@@ -5,21 +5,20 @@ import dash_html_components as html
 def refs_layout(app):
     layout = html.Div([
         dcc.Markdown("""
-## Funding
+### Funding
 
 The _propnet_ project is part of the Accelerated Materials Design and Discovery program, funded by
 [Toyota Research Institute](https://www.tri.global/research/).
 
-## Sources
-The propnet codebase uses data and functionality from a number of open-source databases and repositories.
+### Sources
+The _propnet_ codebase uses data and functionality from a number of open-source databases and repositories.
 For more detailed information regarding these sources, please see the following references. For reference
 information on individual properties and models, please see the respective model or symbol detail page.
 """),
         html.Details([
-            html.Summary(html.H4("The Materials Project",
-                                 style={'display': 'inline'}),
-                         style={'display': 'flex',
-                                'align-items': 'center'}),
+            html.Summary(html.H5("The Materials Project",
+                                 style={'display': 'inline-block',
+                                        'vertical-align': 'middle'})),
             dcc.Markdown("""
 > Anubhav Jain, Shyue Ping Ong, Geoffroy Hautier, Wei Chen, William Davidson Richards, Stephen Dacek, Shreyas Cholia, Dan Gunter, David Skinner, Gerbrand Ceder, and Kristin A\. Persson\.
 The Materials Project: A materials genome approach to accelerating materials innovation\.
@@ -27,10 +26,9 @@ The Materials Project: A materials genome approach to accelerating materials inn
 URL: [https://aip\.scitation\.org/doi/10\.1063/1\.4812323](https://aip.scitation.org/doi/10.1063/1.4812323), [doi:10\.1063/1\.4812323](https://doi.org/10.1063/1.4812323)\.
 """)]),
         html.Details([
-            html.Summary(html.H4("Pymatgen",
-                                 style={'display': 'inline'}),
-                         style={'display': 'flex',
-                                'align-items': 'center'}),
+            html.Summary(html.H5("Pymatgen",
+                                 style={'display': 'inline-block',
+                                        'vertical-align': 'middle'})),
             dcc.Markdown("""
 > Shyue Ping Ong, William Davidson Richards, Anubhav Jain, Geoffroy Hautier, Michael Kocher, Shreyas Cholia, Dan Gunter, Vincent L\. Chevrier, Kristin A\. Persson, and Gerbrand Ceder\.
 Python materials genomics \(pymatgen\): a robust, open\-source python library for materials analysis\.
@@ -38,10 +36,9 @@ Python materials genomics \(pymatgen\): a robust, open\-source python library fo
 URL: [https://doi\.org/10\.1016%2Fj\.commatsci\.2012\.10\.028](https://doi.org/10.1016%2Fj.commatsci.2012.10.028), [doi:10\.1016/j\.commatsci\.2012\.10\.028](https://doi.org/10.1016/j.commatsci.2012.10.028)\.  
 """)]),
         html.Details([
-            html.Summary(html.H4("AFLOW / AFLUX",
-                                 style={'display': 'inline'}),
-                         style={'display': 'flex',
-                                'align-items': 'center'}),
+            html.Summary(html.H5("AFLOW / AFLUX",
+                                 style={'display': 'inline-block',
+                                        'vertical-align': 'middle'})),
             dcc.Markdown("""
 > Stefano Curtarolo, Wahyu Setyawan, Gus L\.W\. Hart, Michal Jahnatek, Roman V\. Chepulskii, Richard H\. Taylor, Shidong Wang, Junkai Xue, Kesong Yang, Ohad Levy, Michael J\. Mehl, Harold T\. Stokes, Denis O\. Demchenko, and Dane Morgan\.
 AFLOW: an automatic framework for high\-throughput materials discovery\.
@@ -59,10 +56,9 @@ AFLUX: the LUX materials search API for the AFLOW data repositories\.
 URL: [https://doi\.org/10\.1016%2Fj\.commatsci\.2017\.04\.036](https://doi.org/10.1016%2Fj.commatsci.2017.04.036), [doi:10\.1016/j\.commatsci\.2017\.04\.036](https://doi.org/10.1016/j.commatsci.2017.04.036)\.  
 """)]),
         html.Details([
-            html.Summary(html.H4("AFLUX API Python Wrapper",
-                                 style={'display': 'inline'}),
-                         style={'display': 'flex',
-                                'align-items': 'center'}),
+            html.Summary(html.H5("AFLUX API Python Wrapper",
+                                 style={'display': 'inline-block',
+                                        'vertical-align': 'middle'})),
             dcc.Markdown("""
 > Conrad W\. Rosenbrock\.
 A practical Python API for querying AFLOWLIB\.

--- a/propnet/web/layouts_home.py
+++ b/propnet/web/layouts_home.py
@@ -10,10 +10,9 @@ def home_layout():
                   style={'text-align': 'center'}),
          html.Br(),
          html.Details([
-             html.Summary(html.H4("What is propnet?",
-                                  style={'display': 'inline'}),
-                          style={'display': 'flex',
-                                 'align-items': 'center'}),
+             html.Summary(html.H5("What is propnet?",
+                                  style={'display': 'inline-block',
+                                         'vertical-align': 'middle'})),
              dcc.Markdown("""
 Property data and relationships between properties are the fundamental bases of scientific knowledge. 
 These building blocks connect to form a web or graph of knowledge that can traverse different scientific domains.
@@ -33,10 +32,9 @@ In _propnet_, we have codified these properties and relationships with the follo
                          style={'margin-bottom': 0})])
          ]),
          html.Details([
-             html.Summary(html.H4("What is on this website?",
-                                  style={'display': 'inline'}),
-                          style={'display': 'flex',
-                                 'align-items': 'center'}),
+             html.Summary(html.H5("What is on this website?",
+                                  style={'display': 'inline-block',
+                                         'vertical-align': 'middle'})),
              dcc.Markdown("""
 The purpose of this site is to demonstrate some of the features available in the _propnet_ package:
 """),
@@ -44,14 +42,14 @@ The purpose of this site is to demonstrate some of the features available in the
                  html.Li(
                      html.P([
                          html.B("Explore"), " allows you to see what properties (symbols) and "
-                         "models are currently built into ", html.Em("propnet"),
+                                            "models are currently built into ", html.Em("propnet"),
                          " (as of the last website build)."],
                          style={'display': 'inline'}),
                      style={'margin-bottom': 0}),
                  html.Li(
                      html.P([
                          html.B("Generate"), " allows you to run the graph traversal algorithm "
-                         "on your own data or data imported from ",
+                                             "on your own data or data imported from ",
                          html.A("Materials Project", href="https://materialsproject.org"), " or ",
                          html.A("AFLOW", href="http://aflowlib.org"), "."],
                          style={'display': 'inline'}),
@@ -59,28 +57,27 @@ The purpose of this site is to demonstrate some of the features available in the
                  html.Li(
                      html.P([
                          html.B("Correlate"), " allows you to explore different metrics used to "
-                         "correlate scalar properties calculated from MP data."],
+                                              "correlate scalar properties calculated from MP data."],
                          style={'display': 'inline'}),
                      style={'margin-bottom': 0}),
                  html.Li(
                      html.P([
                          html.B("Plot"), " allows you to plot two, three, or four scalar "
-                         "properties against one another. This information pairs with Correlate data."],
+                                         "properties against one another. This information pairs with Correlate data."],
                          style={'display': 'inline'}),
                      style={'margin-bottom': 0}),
                  html.Li(
                      html.P([
                          html.B("References"), " shows citations for our database data and for some of "
-                         "our key analysis/retrieval packages."],
+                                               "our key analysis/retrieval packages."],
                          style={'display': 'inline'}),
                      style={'margin-bottom': 0})
              ])
          ]),
          html.Details([
-             html.Summary(html.H4("How can I apply propnet to my own data?",
-                                  style={'display': 'inline'}),
-                          style={'display': 'flex',
-                                 'align-items': 'center'}),
+             html.Summary(html.H5("How can I apply propnet to my own data?",
+                                  style={'display': 'inline-block',
+                                         'vertical-align': 'middle'})),
              dcc.Markdown("""
 A design goal of this project is to make it easily accessible for scientists who aren't coding experts.
 Please see our [demo notebook](https://github.com/materialsintelligence/propnet/blob/master/demo/Getting%20Started.ipynb)
@@ -88,10 +85,9 @@ for a step-by-step example of how to apply _propnet_ to your own data. If you ha
 you can also apply _propnet_ to an MP material.
 """)]),
          html.Details([
-             html.Summary(html.H4("How powerful is propnet?",
-                                  style={'display': 'inline'}),
-                          style={'display': 'flex',
-                                 'align-items': 'center'}),
+             html.Summary(html.H5("How powerful is propnet?",
+                                  style={'display': 'inline-block',
+                                         'vertical-align': 'middle'})),
              dcc.Markdown("""
 To demonstrate the power of propnet, we connected it to the materials in the Materials Project database.
 Applying our graph traversal algorithm, we were able to expand the total number of known properties 
@@ -101,10 +97,9 @@ As the code base grows with more models and properties, more data can be derived
 contributions of models and properties (symbols). Please contact us via our GitHub page (linked below).
 """)]),
          html.Details([
-             html.Summary(html.H4("Where can I download the code or make a suggestion?",
-                                  style={'display': 'inline'}),
-                          style={'display': 'flex',
-                                 'align-items': 'center'}),
+             html.Summary(html.H5("Where can I download the code or make a suggestion?",
+                                  style={'display': 'inline-block',
+                                         'vertical-align': 'middle'})),
              dcc.Markdown("""
 Our GitHub repository is available [here](https://github.com/materialsintelligence/propnet).
 If you would like to test _propnet_ locally, please clone the repository, `pip install -r requirements.txt`


### PR DESCRIPTION
Was using a flex box, but this feature doesn't work well in safari. Used different approach to align arrows in collapsable content.