### PR TITLE
Fix/suppress pint warning, update 2 model names

### DIFF
--- a/demo/Getting Started.ipynb
+++ b/demo/Getting Started.ipynb
@@ -468,7 +468,7 @@
       "From the Maxwell Relations, the index of refraction is equal to the geometric mean\n",
       "of the relative permittivity and the relative permeability.\n",
       "\n",
-      "refractive_indexfrom_rel_perm\n",
+      "refractive_index_from_rel_perm\n",
       "\n",
       "['n = sqrt(Ur*Er)']\n"
      ]
@@ -479,7 +479,7 @@
     "from propnet.core.graph import Graph\n",
     "g = Graph()\n",
     "# This information can be obtained from Registry(\"models\") as well\n",
-    "model = g.get_models()['refractive_indexfrom_rel_perm']\n",
+    "model = g.get_models()['refractive_index_from_rel_perm']\n",
     "print(model.description)\n",
     "print(model.name)\n",
     "print()\n",

--- a/propnet/core/quantity.py
+++ b/propnet/core/quantity.py
@@ -913,7 +913,7 @@ class NumQuantity(BaseQuantity):
             rhs_convert = rhs.to(units_for_comparison)
         except DimensionalityError:
             return False
-        return np.allclose(lhs_convert, rhs_convert)
+        return np.allclose(lhs_convert.magnitude, rhs_convert.magnitude)
 
     def __hash__(self):
         """

--- a/propnet/core/tests/test_graph.py
+++ b/propnet/core/tests/test_graph.py
@@ -422,19 +422,19 @@ class GraphTest(unittest.TestCase):
         # Expected outputs
         s_outputs = permeability + permittivity + [
             QuantityFactory.create_quantity('refractive_index', 3 ** 0.5,
-                                            provenance=ProvenanceElement(model="refractive_indexfrom_rel_perm",
+                                            provenance=ProvenanceElement(model="refractive_index_from_rel_perm",
                                                                          inputs=[permeability[0],
                                                                                  permittivity[0]])),
             QuantityFactory.create_quantity('refractive_index', 5 ** 0.5,
-                                            provenance=ProvenanceElement(model="refractive_indexfrom_rel_perm",
+                                            provenance=ProvenanceElement(model="refractive_index_from_rel_perm",
                                                                          inputs=[permeability[0],
                                                                                  permittivity[1]])),
             QuantityFactory.create_quantity('refractive_index', 6 ** 0.5,
-                                            provenance=ProvenanceElement(model="refractive_indexfrom_rel_perm",
+                                            provenance=ProvenanceElement(model="refractive_index_from_rel_perm",
                                                                          inputs=[permeability[1],
                                                                                  permittivity[0]])),
             QuantityFactory.create_quantity('refractive_index', 10 ** 0.5,
-                                            provenance=ProvenanceElement(model="refractive_indexfrom_rel_perm",
+                                            provenance=ProvenanceElement(model="refractive_index_from_rel_perm",
                                                                          inputs=[permeability[1],
                                                                                  permittivity[1]]))]
 

--- a/propnet/dbtools/mp_builder.py
+++ b/propnet/dbtools/mp_builder.py
@@ -217,8 +217,8 @@ class PropnetBuilder(MapBuilder):
                 # No new quantities were derived
                 continue
             # Store mean and std dev for aggregated quantities
-            sub_doc = {"mean": unumpy.nominal_values(quantity.value).tolist(),
-                       "std_dev": unumpy.std_devs(quantity.value).tolist(),
+            sub_doc = {"mean": unumpy.nominal_values(quantity.magnitude).tolist(),
+                       "std_dev": unumpy.std_devs(quantity.magnitude).tolist(),
                        "units": quantity.units.format_babel() if quantity.units else None,
                        "title": quantity.symbol.display_names[0]}
             # Symbol Name -> Sub_Document, listing all Quantities of that type.

--- a/propnet/dbtools/tests/test_storage.py
+++ b/propnet/dbtools/tests/test_storage.py
@@ -1,18 +1,18 @@
 import unittest
 import os
+import copy
+from itertools import chain
+import warnings
 
 import numpy as np
+from monty.json import jsanitize, MontyDecoder
+from pint import UnitStrippedWarning
 
 from propnet.dbtools.storage import StorageQuantity, ProvenanceStore, ProvenanceStoreQuantity
 from propnet.core.symbols import Symbol
 from propnet.core.quantity import QuantityFactory, NumQuantity, BaseQuantity
 from propnet.core.provenance import ProvenanceElement
 from propnet import ureg
-
-from monty.json import jsanitize, MontyDecoder
-import copy
-from itertools import chain
-
 # noinspection PyUnresolvedReferences
 from propnet.models import add_builtin_models_to_registry
 from propnet.core.registry import Registry
@@ -23,6 +23,8 @@ TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 class StorageTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        # Suppress warnings when using numpy functions with pint Quantities
+        warnings.filterwarnings("ignore", category=UnitStrippedWarning)
         add_builtin_models_to_registry()
         # Inspiration was taken from the GraphTest class
         # I tried to construct the dictionaries for comparison
@@ -233,6 +235,7 @@ class StorageTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        warnings.resetwarnings()
         non_builtin_syms = [k for k, v in Registry("symbols").items() if not v.is_builtin]
         for sym in non_builtin_syms:
             Registry("symbols").pop(sym)
@@ -513,6 +516,7 @@ class StorageTest(unittest.TestCase):
             self.assertIsInstance(q_from_json_dict, StorageQuantity)
             self.assertEqual(q_from_json_dict._data_type, "NumQuantity")
             self.assertEqual(q_from_json_dict.symbol, q.symbol)
+
             self.assertTrue(np.isclose(q_from_json_dict.value, q.magnitude))
             self.assertEqual(q_from_json_dict.units, q.units)
             self.assertListEqual(q_from_json_dict.tags, q.tags)

--- a/propnet/dbtools/tests/test_storage.py
+++ b/propnet/dbtools/tests/test_storage.py
@@ -235,7 +235,7 @@ class StorageTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        warnings.resetwarnings()
+        warnings.filterwarnings("default", category=UnitStrippedWarning)
         non_builtin_syms = [k for k, v in Registry("symbols").items() if not v.is_builtin]
         for sym in non_builtin_syms:
             Registry("symbols").pop(sym)

--- a/propnet/models/serialized/el_resistivity_from_el_conductivity.yaml
+++ b/propnet/models/serialized/el_resistivity_from_el_conductivity.yaml
@@ -7,7 +7,7 @@ description: 'The electrical resistivity and conductivity are related by a simpl
   '
 equations:
 - sigma = 1/rho
-name: el_resistivityfrom_el_conductivity
+name: el_resistivity_from_el_conductivity
 implemented_by:
 - lweston
 references:

--- a/propnet/models/serialized/refractive_index_from_rel_perm.yaml
+++ b/propnet/models/serialized/refractive_index_from_rel_perm.yaml
@@ -19,7 +19,7 @@ description: 'The refractive index gives the factor by which the speed of light 
   '
 equations:
 - n = sqrt(Ur*Er)
-name: refractive_indexfrom_rel_perm
+name: refractive_index_from_rel_perm
 implemented_by:
 - jpalakapilly
 references:


### PR DESCRIPTION
Fix code that raises UnitStrippedWarning when pint Quantities are fed to numpy. Also update a couple names of models that are missing underscores.