### PR TITLE
Add support for numerical constants

### DIFF
--- a/propnet/core/models.py
+++ b/propnet/core/models.py
@@ -923,9 +923,12 @@ class EquationModel(Model, MSONable):
         for connection in d['_connections']:
             if '_lambdas' in connection.keys():
                 del connection['_lambdas']
+        d['_constants'] = {var: q.to_tuple() for var, q in d['_constants'].items()}
         return d
 
     def __setstate__(self, state):
+        state['_constants'] = {var: ureg.Quantity.from_tuple(q)
+                               for var, q in state['_constants'].items()}
         self.__dict__.update(state)
         self._generate_lambdas()
 

--- a/propnet/data/constants_en.txt
+++ b/propnet/data/constants_en.txt
@@ -12,7 +12,7 @@ Z_0 = mu_0 * c = impedance_of_free_space = characteristic_impedance_of_vacuum
 
 # 0.000 000 29 e-34
 planck_constant = 6.62606957e-34 J s = h
-hbar = planck_constant / (2 * pi) = ħ
+reduced_planck_constant = planck_constant / (2 * pi) = ħ = hbar
 
 # 0.000 80 e-11
 newtonian_constant_of_gravitation = 6.67384e-11 m^3 kg^-1 s^-2

--- a/propnet/models/serialized/debye_temperature.yaml
+++ b/propnet/models/serialized/debye_temperature.yaml
@@ -32,7 +32,7 @@ description: 'Assuming a linear dispersion relationship between angular frequenc
 
   '
 equations:
-- T = (6*3.14159**2*p*1E10**3*v**3)**(1/3) * 6.626E-34/2/3.14159 / 1.38E-23
+- T = (6 * pi**2 * p * v**3)**(1/3) * hbar / kb
 name: debye_temperature
 implemented_by:
 - mkhorton
@@ -40,17 +40,16 @@ references:
 - url:https://en.wikipedia.org/wiki/Debye_model
 - doi:10.1002/andp.19123441404
 - url:https://eng.libretexts.org/Bookshelves/Materials_Science/Supplemental_Modules_(Materials_Science)/Electronic_Properties/Debye_Model_For_Specific_Heat
-units_for_evaluation:
-  T: kelvin
-  p: atom / angstrom ** 3
-  v: meter / second
+constants:
+  hbar: reduced_planck_constant
+  kb: boltzmann_constant
 variable_symbol_map:
   T: debye_temperature
   p: atomic_density
   v: sound_velocity_mean
 test_data:
 - inputs:
-    p: 0.08656792234059726
-    v: 3478.868431962869
+    p: 0.08656792234059726 atom / angstrom ** 3
+    v: 3478.868431962869 m/s
   outputs:
-    T: 458.3880285036698
+    T: 458.17730257305215 K


### PR DESCRIPTION
Add support for specifying constants like Planck's constant in `EquationModel` equations, so units work automatically and it cleans up unnecessary numbers from equations. Also supports specifying custom constants with dimensions so that units work automatically and there will be less need for "units_for_evaluation".